### PR TITLE
Refactor match time display.

### DIFF
--- a/hooks/useLiveScores.ts
+++ b/hooks/useLiveScores.ts
@@ -332,13 +332,13 @@ const processApiMatch = (event: any): MatchWithScore | null => {
     // Determine the display string for match time/status
     let matchTimeDisplay: string;
     const shortDetail = event.status?.type?.shortDetail; // e.g., "HT", "FT", "1st", "2nd"
-    const displayClock = event.status?.displayClock; // e.g., "45:00+", "90:00"
+    const displayClock = event.status?.displayClock; // e.g., "90'+4'", "45'+2'"
 
     if (shortDetail === "HT" || shortDetail === "FT") {
       matchTimeDisplay = shortDetail; // Use "HT" or "FT" directly
     } else if (isLive && displayClock) {
-      // Use the display clock if live and available, removing potential trailing '+' or similar
-      matchTimeDisplay = displayClock.replace(/['+]/g, "") + "'"; // Ensure apostrophe
+      // Use the display clock directly as provided by the API
+      matchTimeDisplay = displayClock;
     } else {
       // Fallback to short detail or a placeholder if not live or clock unavailable
       matchTimeDisplay = shortDetail || "?";

--- a/types/espn.ts
+++ b/types/espn.ts
@@ -4,9 +4,11 @@
 export interface ESPNResponse {
   leagues?: Array<{
     id: string;
-    uid: string;
+    uid?: string;
     name: string;
     abbreviation: string;
+    slug?: string;
+    midsizeName?: string;
   }>;
   events: Array<ESPNEvent>;
 }
@@ -21,6 +23,15 @@ export interface ESPNEvent {
   name?: string;
   shortName?: string;
   competitions?: Array<ESPNCompetition>;
+  status?: {
+    type?: {
+      state?: string;
+      completed?: boolean;
+      description?: string;
+      shortDetail?: string;
+    };
+    displayClock?: string;
+  };
   venue?: {
     id?: string;
     fullName?: string;
@@ -41,6 +52,25 @@ export interface ESPNCompetition {
     };
   };
   competitors?: Array<ESPNCompetitor>;
+  details?: Array<{
+    scoringPlay?: boolean;
+    team?: {
+      id: string;
+      name?: string;
+    };
+    athletesInvolved?: Array<{
+      displayName?: string;
+      shortName?: string;
+    }>;
+    clock?: {
+      displayValue?: string;
+    };
+    penaltyKick?: boolean;
+    ownGoal?: boolean;
+    type?: {
+      text?: string;
+    };
+  }>;
 }
 
 /**


### PR DESCRIPTION
Added details to the ESPN API interfaces to include more optional fields

Fixes #52 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved match time display by showing the clock exactly as provided by the API, ensuring formats like "90'+4'" or "45'+2'" are displayed correctly.

- **New Features**
  - Enhanced match and league data to include additional details such as league slugs, midsize names, and more comprehensive event and competition metadata for richer live score information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->