### PR TITLE
Removed react-native-splash-screen dependency from package.json and p…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "react-native-reanimated": "~3.16.1",
         "react-native-safe-area-context": "4.12.0",
         "react-native-screens": "~4.4.0",
-        "react-native-splash-screen": "^3.3.0",
         "react-native-toast-message": "^2.3.0",
         "react-native-ui-datepicker": "^3.0.7",
         "react-native-web": "~0.19.13",
@@ -12941,15 +12940,6 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/react-native-splash-screen": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/react-native-splash-screen/-/react-native-splash-screen-3.3.0.tgz",
-      "integrity": "sha512-rGjt6HkoSXxMqH4SQUJ1gnPQlPJV8+J47+4yhgTIan4bVvAwJhEeJH7wWt9hXSdH4+VfwTS0GTaflj1Tw83IhA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react-native": ">=0.57.0"
       }
     },
     "node_modules/react-native-toast-message": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "react-native-reanimated": "~3.16.1",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",
-    "react-native-splash-screen": "^3.3.0",
     "react-native-toast-message": "^2.3.0",
     "react-native-ui-datepicker": "^3.0.7",
     "react-native-web": "~0.19.13",


### PR DESCRIPTION
…ackage-lock.json because it was conflicting with the expo splash screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the "react-native-splash-screen" dependency from the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->