### PR TITLE
Head to head comparison between players in history

### DIFF
--- a/app/style/historyStyles.ts
+++ b/app/style/historyStyles.ts
@@ -8,7 +8,7 @@ import {
 
 const { width: SCREEN_WIDTH } = Dimensions.get("window");
 
-// --- Color Palette (Optional but recommended) ---
+// --- Color Palette ---
 export const colors = {
   primary: "#0275d8",
   primaryLight: "#e3f2fd",
@@ -26,9 +26,9 @@ export const colors = {
   silver: "#adb5bd",
   bronze: "#cd7f32",
   success: "#4caf50",
-  danger: "#dc3545", // Example
-  warning: "#ffc107", // Example
-  info: "#17a2b8", // Example
+  error: '#dc3545', 
+  warning: "#ffc107", 
+  info: "#17a2b8", 
   background: "#f8f9fa",
 };
 
@@ -1056,6 +1056,43 @@ export const styles = StyleSheet.create({
     borderWidth: 2,
     borderColor: colors.primary,
     backgroundColor: colors.primaryLighter,
+  },
+  tooltipOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  tooltipContainer: {
+    width: '80%',
+    maxWidth: 300,
+    backgroundColor: colors.white,
+    borderRadius: 12,
+    overflow: 'hidden',
+    elevation: 5,
+    shadowColor: colors.black,
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 3.84,
+  },
+  tooltipContent: {
+    padding: 16,
+  },
+  tooltipHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  tooltipTitle: {
+    ...textTitle,
+    fontSize: 16,
+  },
+  tooltipDescription: {
+    ...baseText,
+    fontSize: 14,
+    lineHeight: 20,
+    color: colors.textSecondary,
   },
 });
 

--- a/app/style/historyStyles.ts
+++ b/app/style/historyStyles.ts
@@ -533,9 +533,9 @@ export const styles = StyleSheet.create({
     // Text inside rank badge
     ...baseText,
     color: colors.white,
-    fontWeight: 'bold',
+    fontWeight: "bold",
     fontSize: 14,
-    textAlign: 'center',
+    textAlign: "center",
   } as TextStyle,
   commonBadgeText: {
     // Text inside common match badge
@@ -641,17 +641,17 @@ export const styles = StyleSheet.create({
   rankBadge: {
     // Base for rank badges (1, 2, 3)
     ...baseBadge,
-    position: 'absolute',
+    position: "absolute",
     top: 10,
     right: 10,
     width: 28, // Ensure width and height are the same for a circle
     height: 28,
     borderRadius: 14, // Half of width/height for a circle
-    justifyContent: 'center', // Center content vertically
-    alignItems: 'center', // Center content horizontally
+    justifyContent: "center", // Center content vertically
+    alignItems: "center", // Center content horizontally
     zIndex: 10,
     elevation: 3, // Add shadow for Android
-    shadowColor: '#000', // Add shadow for iOS
+    shadowColor: "#000", // Add shadow for iOS
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.2,
     shadowRadius: 1.5,
@@ -904,6 +904,158 @@ export const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     padding: 20,
+  },
+  // Player Comparison Styles
+  sectionHeaderButtons: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    width: "100%",
+  },
+  compareButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    backgroundColor: colors.primaryLight,
+    borderRadius: 16,
+  },
+  compareButtonText: {
+    ...baseText,
+    color: colors.primary,
+    fontSize: 12,
+    fontWeight: "500",
+    marginLeft: 4,
+  },
+  selectionInstructions: {
+    ...baseText,
+    fontSize: 14,
+    color: colors.textMuted,
+    textAlign: "center",
+    marginVertical: 8,
+  },
+  comparisonHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 20,
+  },
+  comparisonHeaderItem: {
+    flex: 2,
+    alignItems: "center",
+  },
+  comparisonVs: {
+    flex: 1,
+    alignItems: "center",
+  },
+  comparisonVsText: {
+    ...textTitle,
+    fontSize: 18,
+    color: colors.textMuted,
+  },
+  comparisonPlayerName: {
+    ...textTitle,
+    fontSize: 16,
+    marginTop: 6,
+  },
+  comparisonSection: {
+    marginBottom: 24,
+    backgroundColor: colors.white,
+    borderRadius: 12,
+    padding: 16,
+    shadowColor: colors.black,
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 2,
+    elevation: 2,
+  },
+  comparisonSectionTitle: {
+    ...textTitle,
+    fontSize: 16,
+    marginBottom: 12,
+  },
+  comparisonStats: {
+    marginTop: 8,
+  },
+  comparisonStatItem: {
+    marginBottom: 16,
+  },
+  comparisonStatHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 4,
+  },
+  comparisonStatLabel: {
+    ...baseText,
+    fontSize: 14,
+    color: colors.textSecondary,
+    marginLeft: 6,
+  },
+  tooltipIcon: {
+    marginLeft: 4,
+  },
+  comparisonValues: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 8,
+  },
+  comparisonValue: {
+    ...textValue,
+    fontSize: 18,
+  },
+  comparisonDivider: {
+    fontSize: 12,
+    color: colors.textMuted,
+    marginHorizontal: 10,
+  },
+  headToHeadRecord: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginTop: 8,
+  },
+  recordItem: {
+    alignItems: "center",
+    flex: 1,
+  },
+  recordValue: {
+    ...textValue,
+    fontSize: 22,
+  },
+  recordLabel: {
+    ...textLabel,
+    fontSize: 12,
+  },
+  performanceStats: {
+    marginTop: 8,
+  },
+  influenceStats: {
+    marginTop: 8,
+  },
+  influenceItem: {
+    marginBottom: 12,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    backgroundColor: colors.lightGray,
+    borderRadius: 8,
+  },
+  influenceLabel: {
+    ...baseText,
+    fontSize: 14,
+    marginBottom: 6,
+  },
+  influenceValues: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  influenceValue: {
+    ...textValue,
+    fontSize: 14,
+  },
+  selectedPlayerCard: {
+    borderWidth: 2,
+    borderColor: colors.primary,
+    backgroundColor: colors.primaryLighter,
   },
 });
 

--- a/components/history/GameHistoryItem.tsx
+++ b/components/history/GameHistoryItem.tsx
@@ -76,6 +76,7 @@ const GameHistoryItem: React.FC<GameHistoryItemProps> = ({
 
       {/* Game Summary Stats - Inlined */}
       <View style={styles.gameSummary}>
+        
         {/* Players Stat */}
         <View style={styles.summaryItem}>
           <Ionicons

--- a/components/history/PlayerComparisonModal.tsx
+++ b/components/history/PlayerComparisonModal.tsx
@@ -1,0 +1,287 @@
+import React from "react";
+import { View, Text, Modal, ScrollView, TouchableOpacity } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { PlayerStat, GameSession } from "./historyTypes";
+import { styles, colors } from "../../app/style/historyStyles";
+import { getPlayerHeadToHeadStats } from "./historyUtils";
+import { Ionicons as IoniconsType } from "@expo/vector-icons/build/Icons";
+
+interface PlayerComparisonModalProps {
+  visible: boolean;
+  onClose: () => void;
+  player1: PlayerStat | null;
+  player2: PlayerStat | null;
+  gameHistory: GameSession[];
+}
+
+
+interface ComparisonStatItemProps {
+  label: string;
+  value1: string | number;
+  value2: string | number;
+  icon: keyof typeof IoniconsType.glyphMap;
+  tooltip?: string; 
+}
+
+const PlayerComparisonModal: React.FC<PlayerComparisonModalProps> = ({
+  visible,
+  onClose,
+  player1,
+  player2,
+  gameHistory,
+}) => {
+  if (!player1 || !player2) return null;
+
+  // Get head-to-head stats
+  const stats = getPlayerHeadToHeadStats(
+    gameHistory,
+    player1.name,
+    player2.name
+  );
+
+  return (
+    <Modal
+      animationType="fade"
+      transparent={true}
+      visible={visible}
+      onRequestClose={onClose}
+    >
+      <View style={styles.modalCenteredView}>
+        <View style={styles.modalView}>
+          {/* Modal Header */}
+          <View style={styles.modalHeader}>
+            <Text style={styles.modalTitle}>Player Comparison</Text>
+            <TouchableOpacity onPress={onClose} style={styles.modalCloseButton}>
+              <Ionicons name="close" size={28} color={colors.textMuted} />
+            </TouchableOpacity>
+          </View>
+
+          {/* Modal Content */}
+          <ScrollView
+            style={styles.modalScrollView}
+            contentContainerStyle={styles.listContent}
+          >
+            {/* Header with player names */}
+            <View style={styles.comparisonHeader}>
+              <View style={styles.comparisonHeaderItem}>
+                <Ionicons
+                  name="person-circle"
+                  size={40}
+                  color={colors.primary}
+                />
+                <Text style={styles.comparisonPlayerName}>{player1.name}</Text>
+              </View>
+
+              <View style={styles.comparisonVs}>
+                <Text style={styles.comparisonVsText}>VS</Text>
+              </View>
+
+              <View style={styles.comparisonHeaderItem}>
+                <Ionicons
+                  name="person-circle"
+                  size={40}
+                  color={colors.secondary}
+                />
+                <Text style={styles.comparisonPlayerName}>{player2.name}</Text>
+              </View>
+            </View>
+
+            {/* Basic Stats Comparison */}
+            <View style={styles.comparisonSection}>
+              <Text style={styles.comparisonSectionTitle}>Basic Stats</Text>
+              <View style={styles.comparisonStats}>
+                {/* Games Played Comparison */}
+                <ComparisonStatItem
+                  label="Games Played"
+                  value1={stats.player1.gamesPlayed}
+                  value2={stats.player2.gamesPlayed}
+                  icon="game-controller"
+                />
+
+                {/* Total Drinks Comparison */}
+                <ComparisonStatItem
+                  label="Total Drinks"
+                  value1={stats.player1.totalDrinks.toFixed(1)}
+                  value2={stats.player2.totalDrinks.toFixed(1)}
+                  icon="beer"
+                />
+
+                {/* Average Per Game Comparison */}
+                <ComparisonStatItem
+                  label="Avg. Drinks/Game"
+                  value1={stats.player1.averagePerGame.toFixed(1)}
+                  value2={stats.player2.averagePerGame.toFixed(1)}
+                  icon="stats-chart"
+                />
+              </View>
+            </View>
+
+            {/* Head-to-Head Record */}
+            <View style={styles.comparisonSection}>
+              <Text style={styles.comparisonSectionTitle}>
+                Head-to-Head Record
+              </Text>
+              <View style={styles.headToHeadRecord}>
+                <View style={styles.recordItem}>
+                  <Text style={styles.recordValue}>
+                    {stats.gamesPlayedTogether}
+                  </Text>
+                  <Text style={styles.recordLabel}>Games Together</Text>
+                </View>
+
+                <View style={styles.recordItem}>
+                  <Text style={[styles.recordValue, { color: colors.primary }]}>
+                    {stats.player1WinsCount}
+                  </Text>
+                  <Text style={styles.recordLabel}>Wins</Text>
+                </View>
+
+                <View style={styles.recordItem}>
+                  <Text style={styles.recordValue}>{stats.tiedGamesCount}</Text>
+                  <Text style={styles.recordLabel}>Ties</Text>
+                </View>
+
+                <View style={styles.recordItem}>
+                  <Text
+                    style={[styles.recordValue, { color: colors.secondary }]}
+                  >
+                    {stats.player2WinsCount}
+                  </Text>
+                  <Text style={styles.recordLabel}>Wins</Text>
+                </View>
+              </View>
+            </View>
+
+            {/* Drinking Performance */}
+            <View style={styles.comparisonSection}>
+              <Text style={styles.comparisonSectionTitle}>
+                Drinking Performance
+              </Text>
+              <View style={styles.performanceStats}>
+                <ComparisonStatItem
+                  label="Max in a Game"
+                  value1={stats.player1MaxInAGame.toFixed(1)}
+                  value2={stats.player2MaxInAGame.toFixed(1)}
+                  icon="flame"
+                />
+
+                <ComparisonStatItem
+                  label="Efficiency"
+                  value1={stats.player1Efficiency.toFixed(2)}
+                  value2={stats.player2Efficiency.toFixed(2)}
+                  icon="flash"
+                  tooltip="Drinks per match"
+                />
+
+                <ComparisonStatItem
+                  label="Top Drinker"
+                  value1={`${stats.player1TopDrinkerCount}x`}
+                  value2={`${stats.player2TopDrinkerCount}x`}
+                  icon="trophy"
+                />
+              </View>
+            </View>
+
+            {/* Influence Section */}
+            <View style={styles.comparisonSection}>
+              <Text style={styles.comparisonSectionTitle}>
+                Drinking Influence
+              </Text>
+              <View style={styles.influenceStats}>
+                <View style={styles.influenceItem}>
+                  <Text style={styles.influenceLabel}>
+                    {player1.name} drinks{" "}
+                    {getInfluenceText(
+                      stats.player1AvgWithPlayer2,
+                      stats.player1AvgWithoutPlayer2
+                    )}{" "}
+                    when playing with {player2.name}
+                  </Text>
+                  <View style={styles.influenceValues}>
+                    <Text style={styles.influenceValue}>
+                      With: {stats.player1AvgWithPlayer2.toFixed(1)}
+                    </Text>
+                    <Text style={styles.influenceValue}>
+                      Without: {stats.player1AvgWithoutPlayer2.toFixed(1)}
+                    </Text>
+                  </View>
+                </View>
+
+                <View style={styles.influenceItem}>
+                  <Text style={styles.influenceLabel}>
+                    {player2.name} drinks{" "}
+                    {getInfluenceText(
+                      stats.player2AvgWithPlayer1,
+                      stats.player2AvgWithoutPlayer1
+                    )}{" "}
+                    when playing with {player1.name}
+                  </Text>
+                  <View style={styles.influenceValues}>
+                    <Text style={styles.influenceValue}>
+                      With: {stats.player2AvgWithPlayer1.toFixed(1)}
+                    </Text>
+                    <Text style={styles.influenceValue}>
+                      Without: {stats.player2AvgWithoutPlayer1.toFixed(1)}
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            </View>
+
+            {/* Timeline Chart would go here */}
+            {/* This would require a charting library like react-native-chart-kit */}
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+// Update the ComparisonStatItem component with proper typing
+const ComparisonStatItem: React.FC<ComparisonStatItemProps> = ({
+  label,
+  value1,
+  value2,
+  icon,
+  tooltip,
+}) => (
+  <View style={styles.comparisonStatItem}>
+    <View style={styles.comparisonStatHeader}>
+      <Ionicons name={icon} size={16} color={colors.textSecondary} />
+      <Text style={styles.comparisonStatLabel}>{label}</Text>
+      {tooltip && (
+        <TouchableOpacity style={styles.tooltipIcon}>
+          <Ionicons
+            name="information-circle-outline"
+            size={14}
+            color={colors.textMuted}
+          />
+        </TouchableOpacity>
+      )}
+    </View>
+    <View style={styles.comparisonValues}>
+      <Text style={[styles.comparisonValue, { color: colors.primary }]}>
+        {value1}
+      </Text>
+      <Text style={styles.comparisonDivider}>vs</Text>
+      <Text style={[styles.comparisonValue, { color: colors.secondary }]}>
+        {value2}
+      </Text>
+    </View>
+  </View>
+);
+
+// Update the getInfluenceText function with proper typing
+const getInfluenceText = (withAvg: number, withoutAvg: number): string => {
+  if (withAvg === 0 || withoutAvg === 0) return "the same";
+
+  const percentChange = ((withAvg - withoutAvg) / withoutAvg) * 100;
+
+  if (percentChange > 20) return "significantly more";
+  if (percentChange > 5) return "more";
+  if (percentChange < -20) return "significantly less";
+  if (percentChange < -5) return "less";
+  return "about the same";
+};
+
+export default PlayerComparisonModal;

--- a/components/history/PlayerComparisonModal.tsx
+++ b/components/history/PlayerComparisonModal.tsx
@@ -4,8 +4,9 @@ import { Ionicons } from "@expo/vector-icons";
 import { PlayerStat, GameSession } from "./historyTypes";
 import { styles, colors } from "../../app/style/historyStyles";
 import { getPlayerHeadToHeadStats } from "./historyUtils";
-import { Ionicons as IoniconsType } from "@expo/vector-icons/build/Icons";
 import TooltipModal from "./TooltipModal";
+
+type IoniconName = keyof typeof Ionicons.glyphMap;
 
 interface PlayerComparisonModalProps {
   visible: boolean;
@@ -19,7 +20,7 @@ interface ComparisonStatItemProps {
   label: string;
   value1: string | number;
   value2: string | number;
-  icon: keyof typeof IoniconsType.glyphMap;
+  icon: IoniconName;
   tooltip?: string;
 }
 

--- a/components/history/PlayerStatsList.tsx
+++ b/components/history/PlayerStatsList.tsx
@@ -92,7 +92,7 @@ const PlayerStatsList: React.FC<PlayerStatsListProps> = ({ playerStats }) => {
     index: number;
   }) => {
     const maxDrinks = Math.max(...playerStats.map((p) => p.totalDrinks));
-    const widthPercentage = Math.max((item.totalDrinks / maxDrinks) * 100, 0);
+    const widthPercentage = maxDrinks === 0 ? 0 : Math.max((item.totalDrinks / maxDrinks) * 100, 0);
     const isSelected = selectedPlayers.find((p) => p.name === item.name);
 
     return (

--- a/components/history/TooltipModal.tsx
+++ b/components/history/TooltipModal.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { View, Text, Modal, TouchableOpacity } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { styles, colors } from "../../app/style/historyStyles";
+
+/**
+ * @interface TooltipModalProps
+ * @brief Props for the TooltipModal component.
+ * @property {boolean} visible - Whether the tooltip modal is visible.
+ * @property {() => void} onClose - Function to call when the modal is closed.
+ * @property {string} title - The title text to display in the tooltip.
+ * @property {string} description - The description text to display in the tooltip.
+ */
+interface TooltipModalProps {
+  visible: boolean;
+  onClose: () => void;
+  title: string;
+  description: string;
+}
+
+/**
+ * @component TooltipModal
+ * @brief A modal component that displays helpful tooltip information.
+ * 
+ * This component renders a modal with a title and description to provide
+ * additional context or explanation for a feature. The modal can be closed
+ * by pressing the close button or tapping anywhere outside the tooltip content.
+ * 
+ * @param {TooltipModalProps} props - The props for the component.
+ * @returns {React.ReactElement} The rendered TooltipModal component.
+ */
+const TooltipModal: React.FC<TooltipModalProps> = ({
+  visible,
+  onClose,
+  title,
+  description,
+}) => {
+  return (
+    <Modal
+      animationType="fade"
+      transparent={true}
+      visible={visible}
+      onRequestClose={onClose}
+    >
+      <TouchableOpacity
+        style={styles.tooltipOverlay}
+        activeOpacity={1}
+        onPress={onClose}
+      >
+        <View style={styles.tooltipContainer}>
+          <View style={styles.tooltipContent}>
+            <View style={styles.tooltipHeader}>
+              <Text style={styles.tooltipTitle}>{title}</Text>
+              <TouchableOpacity onPress={onClose}>
+                <Ionicons name="close" size={20} color={colors.textMuted} />
+              </TouchableOpacity>
+            </View>
+            <Text style={styles.tooltipDescription}>{description}</Text>
+          </View>
+        </View>
+      </TouchableOpacity>
+    </Modal>
+  );
+};
+
+export default TooltipModal;

--- a/components/history/historyTypes.ts
+++ b/components/history/historyTypes.ts
@@ -72,3 +72,73 @@ export interface GameSession {
   playerAssignments: PlayerAssignments;
   matchesPerPlayer: number;
 }
+
+/**
+ * @interface HeadToHeadStats
+ * @brief Represents the statistics of two players head-to-head.
+ * @property {Object} player1 - Statistics for player 1.
+ * @property {string} player1.name - The name of player 1.
+ * @property {number} player1.totalDrinks - The total number of drinks taken by player 1.
+ * @property {number} player1.gamesPlayed - The total number of games played by player 1.
+ * @property {number} player1.averagePerGame - The average number of drinks taken by player 1 per game.
+ * @property {Object} player2 - Statistics for player 2.
+ * @property {string} player2.name - The name of player 2.
+ * @property {number} player2.totalDrinks - The total number of drinks taken by player 2.
+ * @property {number} player2.gamesPlayed - The total number of games played by player 2.
+ * @property {number} player2.averagePerGame - The average number of drinks taken by player 2 per game.
+ * @property {number} gamesPlayedTogether - The total number of games played together by both players.
+ * @property {number} player1WinsCount - The number of games won by player 1.
+ * @property {number} player2WinsCount - The number of games won by player 2.
+ * @property {number} tiedGamesCount - The number of games that ended in a tie.
+ * @property {number} player1MaxInAGame - The maximum number of drinks taken by player 1 in a single game.
+ * @property {number} player2MaxInAGame - The maximum number of drinks taken by player 2 in a single game.
+ * @property {number} player1CommonMatchCount - The number of common matches played by player 1.
+ * @property {number} player2CommonMatchCount - The number of common matches played by player 2.
+ * @property {number} player1Efficiency - The efficiency of player 1.
+ * @property {number} player2Efficiency - The efficiency of player 2.
+ * @property {number} player1TopDrinkerCount - The number of times player 1 was the top drinker.
+ * @property {number} player2TopDrinkerCount - The number of times player 2 was the top drinker.
+ * @property {number} player1AvgWithPlayer2 - The average drinks taken by player 1 when playing with player 2.
+ * @property {number} player1AvgWithoutPlayer2 - The average drinks taken by player 1 when not playing with player 2.
+ * @property {number} player2AvgWithPlayer1 - The average drinks taken by player 2 when playing with player 1.
+ * @property {number} player2AvgWithoutPlayer1 - The average drinks taken by player 2 when not playing with player 1.
+ * @property {Array.<Object>} timelineData - Timeline data of drinks taken by both players.
+ * @property {string} timelineData.date - The date of the game session.
+ * @property {number} timelineData.player1Drinks - The number of drinks taken by player 1 in the game session.
+ * @property {number} timelineData.player2Drinks - The number of drinks taken by player 2 in the game session.
+ */
+export interface HeadToHeadStats {
+  player1: {
+    name: string;
+    totalDrinks: number;
+    gamesPlayed: number;
+    averagePerGame: number;
+  };
+  player2: {
+    name: string;
+    totalDrinks: number;
+    gamesPlayed: number;
+    averagePerGame: number;
+  };
+  gamesPlayedTogether: number;
+  player1WinsCount: number;
+  player2WinsCount: number;
+  tiedGamesCount: number;
+  player1MaxInAGame: number;
+  player2MaxInAGame: number;
+  player1CommonMatchCount: number;
+  player2CommonMatchCount: number;
+  player1Efficiency: number;
+  player2Efficiency: number;
+  player1TopDrinkerCount: number;
+  player2TopDrinkerCount: number;
+  player1AvgWithPlayer2: number;
+  player1AvgWithoutPlayer2: number;
+  player2AvgWithPlayer1: number;
+  player2AvgWithoutPlayer1: number;
+  timelineData: Array<{
+    date: string;
+    player1Drinks: number;
+    player2Drinks: number;
+  }>;
+}

--- a/components/history/historyUtils.ts
+++ b/components/history/historyUtils.ts
@@ -46,17 +46,14 @@ export const findTopDrinker = (players: Player[]): Player | null => {
  * @brief Formats a date string into a readable format for history items.
  * Creates a concise date representation for display in history list items.
  * @param dateString The date string to format.
- * @return The formatted date string with short weekday, month, day, year, and time.
+ * @return The formatted date string with short month, day, and year.
  */
 export const formatHistoryDate = (dateString: string): string => {
   const date = new Date(dateString);
   return date.toLocaleDateString(undefined, {
-    weekday: "short",
     year: "numeric",
     month: "short",
     day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
   });
 };
 

--- a/components/history/historyUtils.ts
+++ b/components/history/historyUtils.ts
@@ -1,4 +1,10 @@
-import { GameSession, Match, Player, PlayerStat } from "./historyTypes";
+import {
+  GameSession,
+  Match,
+  Player,
+  PlayerStat,
+  HeadToHeadStats,
+} from "./historyTypes";
 
 /**
  * @brief Calculates the total goals (home + away) for a list of matches.
@@ -117,4 +123,246 @@ export const calculateLifetimePlayerStats = (
 
   statsArray.sort((a, b) => b.totalDrinks - a.totalDrinks);
   return statsArray;
+};
+
+/**
+ * @brief Calculates comprehensive head-to-head statistics for two players.
+ * @param history An array of GameSession objects.
+ * @param player1Name Name of the first player.
+ * @param player2Name Name of the second player.
+ * @return A HeadToHeadStats object with comparison metrics.
+ */
+export const getPlayerHeadToHeadStats = (
+  history: GameSession[],
+  player1Name: string,
+  player2Name: string
+): HeadToHeadStats => {
+  // Initialize the stats object with default values
+  const stats: HeadToHeadStats = {
+    player1: {
+      name: player1Name,
+      gamesPlayed: 0,
+      totalDrinks: 0,
+      averagePerGame: 0,
+    },
+    player2: {
+      name: player2Name,
+      gamesPlayed: 0,
+      totalDrinks: 0,
+      averagePerGame: 0,
+    },
+    gamesPlayedTogether: 0,
+    player1WinsCount: 0,
+    player2WinsCount: 0,
+    tiedGamesCount: 0,
+    player1MaxInAGame: 0,
+    player2MaxInAGame: 0,
+    player1CommonMatchCount: 0,
+    player2CommonMatchCount: 0,
+    player1Efficiency: 0,
+    player2Efficiency: 0,
+    player1TopDrinkerCount: 0,
+    player2TopDrinkerCount: 0,
+    player1AvgWithPlayer2: 0,
+    player1AvgWithoutPlayer2: 0,
+    player2AvgWithPlayer1: 0,
+    player2AvgWithoutPlayer1: 0,
+    timelineData: [],
+  };
+
+  // Games where each player participated
+  const player1Games = history.filter((game) =>
+    game.players.some((p) => p.name === player1Name)
+  );
+
+  const player2Games = history.filter((game) =>
+    game.players.some((p) => p.name === player2Name)
+  );
+
+  // Games where both players participated
+  const gamesPlayedTogether = history.filter(
+    (game) =>
+      game.players.some((p) => p.name === player1Name) &&
+      game.players.some((p) => p.name === player2Name)
+  );
+
+  // Basic stats
+  stats.player1.gamesPlayed = player1Games.length;
+  stats.player2.gamesPlayed = player2Games.length;
+  stats.gamesPlayedTogether = gamesPlayedTogether.length;
+
+  // Calculate total drinks
+  stats.player1.totalDrinks = player1Games.reduce((total, game) => {
+    const player = game.players.find((p) => p.name === player1Name);
+    return total + (player?.drinksTaken || 0);
+  }, 0);
+
+  stats.player2.totalDrinks = player2Games.reduce((total, game) => {
+    const player = game.players.find((p) => p.name === player2Name);
+    return total + (player?.drinksTaken || 0);
+  }, 0);
+
+  // Calculate averages
+  stats.player1.averagePerGame =
+    stats.player1.gamesPlayed > 0
+      ? stats.player1.totalDrinks / stats.player1.gamesPlayed
+      : 0;
+
+  stats.player2.averagePerGame =
+    stats.player2.gamesPlayed > 0
+      ? stats.player2.totalDrinks / stats.player2.gamesPlayed
+      : 0;
+
+  // Head-to-head analysis in games played together
+  gamesPlayedTogether.forEach((game) => {
+    const player1 = game.players.find((p) => p.name === player1Name);
+    const player2 = game.players.find((p) => p.name === player2Name);
+
+    const player1Drinks = player1?.drinksTaken || 0;
+    const player2Drinks = player2?.drinksTaken || 0;
+
+    // Update max drinks in a game
+    stats.player1MaxInAGame = Math.max(stats.player1MaxInAGame, player1Drinks);
+    stats.player2MaxInAGame = Math.max(stats.player2MaxInAGame, player2Drinks);
+
+    // Track who drank more in each game
+    if (player1Drinks > player2Drinks) {
+      stats.player1WinsCount++;
+    } else if (player2Drinks > player1Drinks) {
+      stats.player2WinsCount++;
+    } else {
+      stats.tiedGamesCount++;
+    }
+
+    // Add timeline data for trend visualization
+    stats.timelineData.push({
+      date: game.date,
+      player1Drinks: player1Drinks,
+      player2Drinks: player2Drinks,
+    });
+  });
+
+  // Sort timeline data by date
+  stats.timelineData.sort(
+    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+  );
+
+  // Common match participation
+  player1Games.forEach((game) => {
+    if (
+      game.players.some((p) => p.name === player1Name) &&
+      game.matches.some((m) => m.id === game.commonMatchId)
+    ) {
+      stats.player1CommonMatchCount++;
+    }
+  });
+
+  player2Games.forEach((game) => {
+    if (
+      game.players.some((p) => p.name === player2Name) &&
+      game.matches.some((m) => m.id === game.commonMatchId)
+    ) {
+      stats.player2CommonMatchCount++;
+    }
+  });
+
+  // Calculate efficiency (drinks per match)
+  const player1TotalMatches = player1Games.reduce(
+    (total, game) => total + game.matches.length,
+    0
+  );
+
+  const player2TotalMatches = player2Games.reduce(
+    (total, game) => total + game.matches.length,
+    0
+  );
+
+  stats.player1Efficiency =
+    player1TotalMatches > 0
+      ? stats.player1.totalDrinks / player1TotalMatches
+      : 0;
+
+  stats.player2Efficiency =
+    player2TotalMatches > 0
+      ? stats.player2.totalDrinks / player2TotalMatches
+      : 0;
+
+  // Top drinker frequency
+  player1Games.forEach((game) => {
+    const topDrinker = findTopDrinker(game.players);
+    if (topDrinker && topDrinker.name === player1Name) {
+      stats.player1TopDrinkerCount++;
+    }
+  });
+
+  player2Games.forEach((game) => {
+    const topDrinker = findTopDrinker(game.players);
+    if (topDrinker && topDrinker.name === player2Name) {
+      stats.player2TopDrinkerCount++;
+    }
+  });
+
+  // Calculate drinking influence - player1 with vs without player2
+  if (stats.gamesPlayedTogether > 0) {
+    const player1DrinksWithPlayer2 = gamesPlayedTogether.reduce(
+      (total, game) => {
+        const player = game.players.find((p) => p.name === player1Name);
+        return total + (player?.drinksTaken || 0);
+      },
+      0
+    );
+
+    stats.player1AvgWithPlayer2 =
+      player1DrinksWithPlayer2 / stats.gamesPlayedTogether;
+  }
+
+  const player1GamesWithoutPlayer2 = player1Games.filter(
+    (game) => !game.players.some((p) => p.name === player2Name)
+  );
+
+  if (player1GamesWithoutPlayer2.length > 0) {
+    const player1DrinksWithoutPlayer2 = player1GamesWithoutPlayer2.reduce(
+      (total, game) => {
+        const player = game.players.find((p) => p.name === player1Name);
+        return total + (player?.drinksTaken || 0);
+      },
+      0
+    );
+
+    stats.player1AvgWithoutPlayer2 =
+      player1DrinksWithoutPlayer2 / player1GamesWithoutPlayer2.length;
+  }
+
+  // Calculate drinking influence - player2 with vs without player1
+  if (stats.gamesPlayedTogether > 0) {
+    const player2DrinksWithPlayer1 = gamesPlayedTogether.reduce(
+      (total, game) => {
+        const player = game.players.find((p) => p.name === player2Name);
+        return total + (player?.drinksTaken || 0);
+      },
+      0
+    );
+
+    stats.player2AvgWithPlayer1 =
+      player2DrinksWithPlayer1 / stats.gamesPlayedTogether;
+  }
+
+  const player2GamesWithoutPlayer1 = player2Games.filter(
+    (game) => !game.players.some((p) => p.name === player1Name)
+  );
+
+  if (player2GamesWithoutPlayer1.length > 0) {
+    const player2DrinksWithoutPlayer1 = player2GamesWithoutPlayer1.reduce(
+      (total, game) => {
+        const player = game.players.find((p) => p.name === player2Name);
+        return total + (player?.drinksTaken || 0);
+      },
+      0
+    );
+
+    stats.player2AvgWithoutPlayer1 =
+      player2DrinksWithoutPlayer1 / player2GamesWithoutPlayer1.length;
+  }
+
+  return stats;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a player comparison feature, allowing users to select two players and view a detailed side-by-side comparison of their game statistics, head-to-head records, and drinking influence.
  - Added interactive tooltips with explanations for comparison stats.
  - Enhanced UI with new styles for comparison components and tooltips.
  - Added a toggle button to enter comparison mode and select players for comparison.
  - Implemented a modal to display tooltip information with title and description.

- **Bug Fixes**
  - Improved date formatting in game history for clearer display.

- **Documentation**
  - Added new interface definitions for head-to-head player statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->