### PR TITLE
Refactor top drinker logic to support multiple top drinkers and update display accordingly

### DIFF
--- a/components/history/GameHistoryItem.tsx
+++ b/components/history/GameHistoryItem.tsx
@@ -116,14 +116,19 @@ const GameHistoryItem: React.FC<GameHistoryItemProps> = ({
         </View>
       </View>
 
-      {/* Top Drinker Highlight */}
-      {topDrinker && (
+            {/* Top Drinker Highlight */}
+      {topDrinker.length > 0 && (
         <View style={styles.topDrinkerContainer}>
           <Ionicons name="flame" size={18} color={colors.warning} />
           <Text style={styles.topDrinkerText} numberOfLines={1}>
-            {"Top Drinker: "}
-            <Text style={styles.topDrinkerName}>{topDrinker.name}</Text>
-            <Text> ({topDrinker.drinksTaken?.toFixed(1) ?? "0"})</Text>
+            {"Top Drinker" + (topDrinker.length > 1 ? "s" : "") + ": "}
+            {topDrinker.map((player, index) => (
+              <React.Fragment key={player.name}>
+                <Text style={styles.topDrinkerName}>{player.name}</Text>
+                <Text>{` (${player.drinksTaken?.toFixed(1) ?? "0"})`}</Text>
+                {index < topDrinker.length - 1 && <Text>, </Text>}
+              </React.Fragment>
+            ))}
           </Text>
         </View>
       )}

--- a/components/history/historyUtils.ts
+++ b/components/history/historyUtils.ts
@@ -30,16 +30,23 @@ export const calculateTotalDrinks = (players: Player[]): number => {
 };
 
 /**
- * Find top drinker.
- * @description Returns the player with the highest drinksTaken value; null if list empty.
+ * Find top drinkers.
+ * @description Returns player(s) with the highest drinksTaken value; empty array if list empty.
  * @param {Player[]} players Player collection.
- * @returns {Player | null} Player with most drinks or null.
+ * @returns {Player[]} Array of players with most drinks (multiple if tied).
  */
-export const findTopDrinker = (players: Player[]): Player | null => {
-  if (players.length === 0) return null;
-  return [...players].sort(
+export const findTopDrinker = (players: Player[]): Player[] => {
+  if (players.length === 0) return [];
+  
+  const sortedPlayers = [...players].sort(
     (a, b) => (b.drinksTaken || 0) - (a.drinksTaken || 0)
-  )[0];
+  );
+  
+  const highestDrinks = sortedPlayers[0].drinksTaken || 0;
+  
+  return sortedPlayers.filter(
+    player => (player.drinksTaken || 0) === highestDrinks
+  );
 };
 
 /**


### PR DESCRIPTION
closes #95 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Game history now shows all top drinkers when there’s a tie, with correct singular/plural labeling.
  - Displays each top drinker’s name with drinks taken rounded to one decimal, separated by commas.

- Bug Fixes
  - Top drinker section is hidden when no data is available, preventing empty or placeholder content.
  - Handles empty player lists gracefully without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->