### PR TITLE
Add row-level security for profiles, friendships, settings, and room data

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # dong Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-05-03
+Auto-generated from all feature plans. Last updated: 2026-05-09
 
 ## Active Technologies
 - TypeScript 5.3.3 in an Expo SDK 52 / React Native 0.76.9 workspace + Expo Router 4, React 18.3.1, Zustand 5, AsyncStorage, `react-native-toast-message`, existing `platform/` adapters, and new `tamagui` + `@tamagui/babel-plugin` foundation dependencies (112-setup-game-assignments)
@@ -17,6 +17,8 @@ Auto-generated from all feature plans. Last updated: 2026-05-03
 - N/A; this feature does not change persisted app data (multiplayer)
 - TypeScript 5.3.3 Expo workspace plus SQL migrations executed via Supabase CLI against local Supabase Postgres + Supabase CLI, Supabase Auth/Postgres local stack, pgTAP database tests, `basejump-supabase_test_helpers` for authenticated DB test contexts, existing Expo SDK 52 / React Native 0.76.9 workspace (128-us21-create-the-core-supabase-schema-for-accounts-sessions-participants-matches-assignments-and-events)
 - New top-level `supabase/` workspace for SQL migrations and database tests; Supabase Postgres becomes the canonical multiplayer store while the existing locally persisted session snapshot remains the temporary local cache until client integration ships (128-us21-create-the-core-supabase-schema-for-accounts-sessions-participants-matches-assignments-and-events)
+- TypeScript 5.3.3 in an Expo SDK 52 / React Native 0.76.9 workspace, plus SQL migrations executed through Supabase CLI against local Supabase Postgres + Supabase CLI, Supabase Auth/Postgres local stack, pgTAP database tests, existing Expo Router 4 workspace, existing Supabase `public.accounts` anchor from US2.1 (151-add-data-rls)
+- New `supabase/` workspace in the repo, with additional `public` schema tables for profiles, settings, and friendships, and RLS enabled on those tables plus the existing room tables (151-add-data-rls)
 
 - TypeScript 5.3.3 in an Expo SDK 52 / React Native 0.76.9 workspace + Expo Router 4, React 18.3.1, Zustand 5, AsyncStorage, `expo-av`, `react-native-date-picker`, `react-native-ui-datepicker`, `lottie-react-native`, `react-native-gesture-handler`, `react-native-reanimated`, Jest-Expo 52 (111-add-platform-abstractions)
 - Existing Zustand + AsyncStorage persistence remains unchanged; no new storage for this feature (111-add-platform-abstractions)
@@ -39,8 +41,8 @@ npm test; npm run lint
 Markdown documentation artifact inside a TypeScript 5.3.3 / Expo SDK 52 workspace: Follow standard conventions
 
 ## Recent Changes
+- 151-add-data-rls: Added TypeScript 5.3.3 in an Expo SDK 52 / React Native 0.76.9 workspace, plus SQL migrations executed through Supabase CLI against local Supabase Postgres + Supabase CLI, Supabase Auth/Postgres local stack, pgTAP database tests, existing Expo Router 4 workspace, existing Supabase `public.accounts` anchor from US2.1
 - 128-us21-create-the-core-supabase-schema-for-accounts-sessions-participants-matches-assignments-and-events: Added TypeScript 5.3.3 Expo workspace plus SQL migrations executed via Supabase CLI against local Supabase Postgres + Supabase CLI, Supabase Auth/Postgres local stack, pgTAP database tests, `basejump-supabase_test_helpers` for authenticated DB test contexts, existing Expo SDK 52 / React Native 0.76.9 workspace
-- multiplayer: Added TypeScript 5.3.3 + Expo SDK 52, React Native 0.76.9, React 18.3.1, Expo Router 4, `playwright-bdd` 8.5.0, `@playwright/test` 1.59.1, `react-native-safe-area-context`, `react-native-toast-message`, Zustand 5
 - multiplayer: Added TypeScript 5.3.3 + Expo SDK 52, React Native 0.76.9, React 18.3.1, Expo Router 4, `playwright-bdd` 8.5.0, `@playwright/test` 1.59.1, `react-native-safe-area-context`, `react-native-toast-message`, Zustand 5
 
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,0 @@
-{
-  "mcpServers": {
-    "supabase": {
-      "url": "https://mcp.supabase.com/mcp?project_ref=qccvlhblytuedgmlqfef&features=database,development,docs"
-    }
-  }
-}

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/007-core-supabase-schema"
+  "feature_directory": "specs/008-add-data-rls"
 }

--- a/specs/008-add-data-rls/checklists/requirements.md
+++ b/specs/008-add-data-rls/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Protected Multiplayer Data Access
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-05-09  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Current schema work under specs/007-core-supabase-schema created the room tables and the `accounts` anchor but did not yet add explicit profile, friendship, or settings records. This specification assumes those account-linked records are in scope for this security slice if they do not already exist at implementation start.
+- Direct client writes to protected gameplay data remain out of scope as a public contract; approved multiplayer actions continue through controlled command surfaces.

--- a/specs/008-add-data-rls/contracts/data-access-contract.md
+++ b/specs/008-add-data-rls/contracts/data-access-contract.md
@@ -1,0 +1,59 @@
+# Data Access Contract: Protected Multiplayer Data Access
+
+## Purpose
+
+This contract defines the row-level access boundaries for the data surfaced by issue #125. Direct table access is allowed only where RLS and grants explicitly permit it. Protected room mutations remain behind approved database-command or service-role paths.
+
+## Identity Contexts
+
+| Context                         | Identity Source                                                       | Contract Expectations                                                                            |
+| ------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Signed-in account owner         | `auth.uid()` mapped to `public.accounts.id`                           | Can read and update its own profile and settings rows                                            |
+| Accepted friendship participant | `auth.uid()` mapped to one side of an accepted friendship row         | Can read the other account's profile row, but not that account's settings row                    |
+| Friendship requester/addressee  | `auth.uid()` mapped to the requester or addressee on a friendship row | Can read that friendship row and transition it only when the current lifecycle state allows it   |
+| Room host                       | `auth.uid()` mapped to the host account on a session                  | Can read room data for that session                                                              |
+| Room participant                | `auth.uid()` mapped to a participant account in the session           | Can read room data for that session                                                              |
+| Guest participant               | Join code plus session-scoped guest reclaim token                     | Can join/reclaim through the approved room surface, not through direct unrestricted table access |
+| Service role / DB harness       | Supabase service role or pgTAP fixture context                        | Fixture setup and privileged room mutations only                                                 |
+
+## Table Access Matrix
+
+### `profiles`
+
+- `SELECT`: owner or accepted friendship participant.
+- `INSERT`: owner only.
+- `UPDATE`: owner only.
+- `DELETE`: owner only, if deletion is supported at all.
+
+### `settings`
+
+- `SELECT`: owner only.
+- `INSERT`: owner only.
+- `UPDATE`: owner only.
+- `DELETE`: owner only, if deletion is supported at all.
+
+### `friendships`
+
+- `SELECT`: requester or addressee only.
+- `INSERT`: requester only.
+- `UPDATE`: requester/addressee only, but only for the lifecycle transition they are authorized to perform.
+- `DELETE`: disabled unless the contract explicitly requires hard delete; lifecycle cancellation is preferred as an update.
+
+### Room tables (`game_sessions`, `participants`, `matches`, `assignments`, `gameplay_events`)
+
+- `SELECT`: host or current participant only for the relevant session.
+- `INSERT` / `UPDATE` / `DELETE`: not exposed to general client roles; privileged room mutations occur through approved database commands or service-role paths.
+
+## Invariants
+
+- A signed-in user never gains access to another user's settings row.
+- A signed-in user only sees a profile row for a friend after the friendship is accepted.
+- Friendship rows are only visible to the two involved accounts.
+- Room data is never readable outside the host/participant boundary.
+- Direct client writes to protected room-state records are rejected.
+
+## Implementation Notes
+
+- Use explicit `GRANT` statements alongside `ALTER TABLE ... ENABLE ROW LEVEL SECURITY`.
+- Keep policy predicates index-friendly and avoid exposing helper functions in the `public` schema.
+- Preserve the existing secure room write contract from US2.1; this feature only hardens access around it.

--- a/specs/008-add-data-rls/data-model.md
+++ b/specs/008-add-data-rls/data-model.md
@@ -1,0 +1,119 @@
+# Data Model: Protected Multiplayer Data Access
+
+## Overview
+
+This feature adds the minimal account-linked tables required to secure the multiplayer data surface: `profiles`, `settings`, and `friendships`. It also applies row-level security and explicit grants to the existing room tables from US2.1 so the host/participant boundary is enforced directly in Postgres.
+
+The existing `public.accounts` table remains the durable identity anchor mapped 1:1 to `auth.users`. The new tables hang off that anchor and are protected by RLS:
+
+- `profiles` stores the friend-visible identity row.
+- `settings` stores the owner-only preference row.
+- `friendships` stores the request-based social relationship between two accounts.
+
+## Enumerations
+
+### `friendship_status`
+
+- `pending`
+- `accepted`
+- `declined`
+- `canceled`
+
+## Physical Entities
+
+### Profile
+
+Friend-visible identity row for an authenticated account.
+
+| Field          | Type          | Notes                                                                                                           |
+| -------------- | ------------- | --------------------------------------------------------------------------------------------------------------- |
+| `account_id`   | `uuid`        | Primary key and foreign key to `accounts.id`                                                                    |
+| `display_name` | `text`        | Public-facing display name, nullable only if the product allows fallback from `accounts.preferred_display_name` |
+| `avatar_url`   | `text`        | Nullable profile image reference                                                                                |
+| `bio`          | `text`        | Nullable short profile description                                                                              |
+| `created_at`   | `timestamptz` | Default `now()`                                                                                                 |
+| `updated_at`   | `timestamptz` | Default `now()`                                                                                                 |
+
+**Relationships**
+
+- One profile belongs to exactly one account.
+- Accepted friendships may read the profile row.
+
+**Validation rules**
+
+- `account_id` must reference an existing account.
+- One profile row exists per account.
+- Only the owner may update the row.
+
+### Settings
+
+Owner-only preference row for an authenticated account.
+
+| Field           | Type          | Notes                                               |
+| --------------- | ------------- | --------------------------------------------------- |
+| `account_id`    | `uuid`        | Primary key and foreign key to `accounts.id`        |
+| `settings_data` | `jsonb`       | Structured preference payload, default empty object |
+| `created_at`    | `timestamptz` | Default `now()`                                     |
+| `updated_at`    | `timestamptz` | Default `now()`                                     |
+
+**Relationships**
+
+- One settings row belongs to exactly one account.
+- Only the owner may read or update the row.
+
+**Validation rules**
+
+- `account_id` must reference an existing account.
+- One settings row exists per account.
+- Settings data is never readable by other signed-in users.
+
+### Friendship
+
+Request-based bilateral relationship between two authenticated accounts.
+
+| Field                  | Type                | Notes                                        |
+| ---------------------- | ------------------- | -------------------------------------------- |
+| `id`                   | `uuid`              | Primary key                                  |
+| `requester_account_id` | `uuid`              | Account that initiated the request           |
+| `addressee_account_id` | `uuid`              | Account that received the request            |
+| `status`               | `friendship_status` | Lifecycle state                              |
+| `requested_at`         | `timestamptz`       | Default `now()`                              |
+| `responded_at`         | `timestamptz`       | Nullable timestamp for accept/decline/cancel |
+| `created_at`           | `timestamptz`       | Default `now()`                              |
+| `updated_at`           | `timestamptz`       | Default `now()`                              |
+
+**Relationships**
+
+- One friendship row belongs to exactly two accounts.
+- Accepted friendships unlock profile reads between the two accounts.
+
+**Validation rules**
+
+- `requester_account_id` and `addressee_account_id` must both reference existing accounts.
+- The requester and addressee must be different accounts.
+- Exactly one friendship row may exist for an unordered pair of accounts.
+- Pending requests may transition to `accepted`, `declined`, or `canceled`.
+- Accepted friendships may transition to `canceled` when the relationship ends.
+
+## Relationship Summary
+
+- `auth.users` 1:1 `accounts`
+- `accounts` 1:1 `profiles`
+- `accounts` 1:1 `settings`
+- `accounts` 1:n `friendships` as requester
+- `accounts` 1:n `friendships` as addressee
+- `game_sessions` 1:n `participants`, `matches`, `assignments`, `gameplay_events`
+
+## Access Model Summary
+
+- `profiles`: owner read/write; accepted friendship participants may read.
+- `settings`: owner read/write only.
+- `friendships`: involved accounts may read; lifecycle state changes are limited to the requester/addressee rules defined in the contract.
+- Room tables: host/participant read access only; privileged writes stay behind approved database-command or service-role paths.
+
+## Database Invariants
+
+- Every account has at most one profile row and one settings row.
+- Friendship rows are unique per unordered pair of accounts.
+- Accepted friendship is the only state that unlocks friend-readable profile access.
+- Room-table access stays scoped to the session host or current participants.

--- a/specs/008-add-data-rls/plan.md
+++ b/specs/008-add-data-rls/plan.md
@@ -1,0 +1,71 @@
+# Implementation Plan: Protected Multiplayer Data Access
+
+**Branch**: `125-us22-add-row-level-security-for-profiles-friendships-settings-and-room-data` | **Date**: 2026-05-09 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from [spec.md](spec.md)
+
+## Summary
+
+Add row-level security and explicit data grants for the multiplayer schema while introducing the minimal account-linked `profiles`, `settings`, and `friendships` tables required by issue #125. The implementation is database-first: Supabase migrations add the new tables, RLS policies, grants, and supporting indexes; pgTAP tests verify allowed and denied access for profile, friendship, and room data; no Expo UI changes ship in this slice.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.3.3 in an Expo SDK 52 / React Native 0.76.9 workspace, plus SQL migrations executed through Supabase CLI against local Supabase Postgres  
+**Primary Dependencies**: Supabase CLI, Supabase Auth/Postgres local stack, pgTAP database tests, existing Expo Router 4 workspace, existing Supabase `public.accounts` anchor from US2.1  
+**Storage**: New `supabase/` workspace in the repo, with additional `public` schema tables for profiles, settings, and friendships, and RLS enabled on those tables plus the existing room tables  
+**Testing**: pgTAP database coverage for permitted/denied reads and writes across profiles, settings, friendships, and room data; no new UI end-to-end coverage  
+**Applicable Skills**: supabase, supabase-postgres-best-practices, database-testing, database-design-expert  
+**Target Platform**: Local Supabase/Postgres used by the existing cross-platform Expo app, with behavior shared by native and web clients  
+**Project Type**: Cross-platform Expo application with a first-party Supabase database workspace  
+**Performance Goals**: Keep policy predicates index-backed; use simple `auth.uid()` checks and `exists` lookups on indexed account/session columns; avoid broad cross-table scans in policy paths  
+**Constraints**: Every public table touched by the feature must have explicit grants and RLS; profile reads expand only to accepted friendship participants; settings remain owner-only; room data remains host/participant scoped and privileged writes stay behind approved database commands or service-role paths  
+**Scale/Scope**: One Supabase workspace, three new account-linked tables, RLS on those tables and the existing room tables, supporting indexes, and a focused pgTAP validation set
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+- PASS: The feature defines consistent native and web behavior by keeping the change in the shared database layer; no UI divergence is introduced.
+- PASS: The canonical source of truth for shared room state remains Supabase Postgres, and privileged room mutations stay behind approved database-command or service-role paths.
+- PASS: The data model introduces additional account-linked tables and explicitly scopes RLS and migration work for profiles, friendships, settings, and room data.
+- PASS: The work is sliced into independently testable user stories with Gherkin-style acceptance criteria and explicit edge cases.
+- PASS: The test strategy uses pgTAP to cover allowed and rejected access patterns at the database layer, which is the highest-leverage level for this feature.
+- PASS: Applicable repository and domain skills were identified before the plan was written: Supabase, Postgres best practices, database testing, and database design.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-add-data-rls/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── data-access-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+supabase/
+├── config.toml
+├── migrations/
+└── tests/
+    └── database/
+package.json
+README.md
+app/
+components/
+hooks/
+store/
+types/
+utils/
+```
+
+**Structure Decision**: This feature stays database-first inside the existing Expo monorepo. All implementation work lands in `supabase/migrations/`, `supabase/tests/database/`, and the supporting docs under `specs/008-add-data-rls/`; the Expo app itself remains unchanged in this slice.
+
+## Complexity Tracking
+
+No constitution violations or exceptional complexity adjustments are required for this feature.

--- a/specs/008-add-data-rls/quickstart.md
+++ b/specs/008-add-data-rls/quickstart.md
@@ -1,0 +1,107 @@
+# Quickstart: Protected Multiplayer Data Access
+
+## Purpose
+
+This quickstart describes how to implement and verify the RLS and grant changes for issue #125 without mixing the work with UI changes or client integration.
+
+## Prerequisites
+
+- Docker Desktop or another supported local container runtime
+- Node.js and npm already used by this repo
+- Supabase CLI available through `npx supabase`
+- Repository root at `C:\src\dong`
+
+## Initial Setup
+
+1. Start the local Supabase stack.
+
+```powershell
+npx supabase start
+```
+
+2. Confirm local service URLs and database status.
+
+```powershell
+npx supabase status
+```
+
+## Implementation Order
+
+1. Create a migration scaffold for the access-control changes.
+
+```powershell
+npx supabase migration new add_profile_friendship_settings_rls
+```
+
+2. Implement the schema in this order:
+
+- `friendship_status` enum
+- `profiles` table
+- `settings` table
+- `friendships` table
+- supporting indexes for profile ownership, settings ownership, friendship lookups, and accepted-friend profile visibility
+- explicit grants for `authenticated` and `service_role`
+- `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` on the new tables and the existing room tables
+- RLS policies for profile, settings, friendship, and room reads and writes
+
+3. Add database tests under `supabase/tests/database/`.
+
+Recommended initial files:
+
+- `000_extensions.test.sql`
+- `010_schema.test.sql`
+- `020_constraints.test.sql`
+- `030_profiles_and_settings_rls.test.sql`
+- `040_friendships_rls.test.sql`
+- `050_room_rls.test.sql`
+- `060_privileged_write_paths.test.sql`
+
+## Authenticated User Testing
+
+Use pgTAP fixtures inside rolled-back transactions to seed `auth.users` rows and matching `public.accounts` rows. If you need an authenticated request context for policy tests, switch the SQL session into the `authenticated` role and set the request JWT claims required by `auth.uid()`-based policies.
+
+Avoid browser or Expo login flows for this feature. The core validation target is the database policy matrix.
+
+## Verification Workflow
+
+1. Reset the local database so migrations apply from scratch.
+
+```powershell
+npx supabase db reset
+```
+
+2. Run the database tests.
+
+```powershell
+npx supabase test db
+```
+
+3. If repository metadata or developer guidance changed, run lint as the final repo-level check.
+
+```powershell
+npm run lint
+```
+
+## Schema Smoke Checklist
+
+- A signed-in user can read and update only their own profile and settings rows.
+- An accepted friendship unlocks profile visibility but not settings visibility.
+- Friendship rows are only visible to the requester and addressee.
+- A room host or current participant can read the room snapshot for that session only.
+- An unrelated user cannot read or mutate another room's data.
+- Direct client writes to protected room-state tables are rejected.
+
+## Out of Scope For This Story
+
+- Expo or browser login UI tests
+- Read models for history, comparisons, or leaderboards
+- One-time local-to-cloud import
+- Client integration with the new tables or RPCs
+
+## Shutdown
+
+When you are done with local database work:
+
+```powershell
+npx supabase stop
+```

--- a/specs/008-add-data-rls/research.md
+++ b/specs/008-add-data-rls/research.md
@@ -1,0 +1,78 @@
+# Research: Protected Multiplayer Data Access
+
+## Decision 1: Add the minimal `profiles`, `settings`, and `friendships` tables now
+
+**Decision**: Treat the feature as policy-plus-minimal-data, not policy-only. Add 1:1 account-linked `profiles` and `settings` tables, plus a request-based `friendships` table.
+
+**Rationale**: The issue explicitly names profiles, friendships, settings, and room data. The current schema only has the `accounts` anchor and room tables, so the RLS story needs actual social/settings rows to protect instead of deferring that work to a later slice.
+
+**Alternatives considered**:
+
+- RLS only on the existing room tables: rejected because it would leave the requested profile/settings surfaces undefined.
+- Defer profile/friendship/settings tables to a follow-up story: rejected because the issue scope and clarified spec expect them in this slice.
+
+## Decision 2: Model friendships as a request-based lifecycle with a single row per unordered pair
+
+**Decision**: Use one `friendships` row per pair of accounts with `requester_account_id`, `addressee_account_id`, and a `friendship_status` enum containing `pending`, `accepted`, `declined`, and `canceled`.
+
+**Rationale**: A request-based lifecycle matches the clarified requirements and keeps the access rules understandable. One row per unordered pair prevents duplicate inverse relationships and keeps accepted-friend profile visibility easy to reason about.
+
+**Alternatives considered**:
+
+- Accepted-friends list only: rejected because it cannot represent pending request transitions.
+- Two directional rows per relationship: rejected because it makes lifecycle and uniqueness rules harder to enforce.
+
+## Decision 3: Keep profiles friend-visible after acceptance, but keep settings owner-only
+
+**Decision**: Let accepted friendship participants read profile rows, while settings remain owner-only for all non-service callers.
+
+**Rationale**: The clarified specification explicitly chose accepted-friend profile visibility. Keeping settings private preserves the personal configuration boundary and avoids exposing preference data through social relationships.
+
+**Alternatives considered**:
+
+- Self-only profiles: rejected because the accepted clarification requires friend-visible profiles.
+- Public profile reads for any signed-in user: rejected because the feature is intended to stop exposure at the friendship boundary.
+
+## Decision 4: Protect room data with RLS and read-only client exposure, not direct client writes
+
+**Decision**: Enable RLS on the existing room tables and keep direct client mutations off those tables. Reads are scoped to the host or current participants of a session, while mutations remain behind the approved database-command or service-role path established by the multiplayer contract.
+
+**Rationale**: The repository already treats room state as server-authoritative and event-backed. This feature should harden that model with database policy, not weaken it by allowing direct table writes from clients.
+
+**Alternatives considered**:
+
+- Allow direct client updates with narrow policies: rejected because it would expose the protected gameplay surface to browser or mobile clients.
+- Move room data into a separate backend service: rejected because the project is Supabase-first and already has the schema in Postgres.
+
+## Decision 5: Use explicit grants together with RLS
+
+**Decision**: Add explicit `GRANT` statements for the roles that should reach each table or function. Treat grants and RLS as a single migration concern.
+
+**Rationale**: Supabase no longer auto-exposes every new public table the way older projects did. The Data API now requires explicit role privileges, and RLS only filters rows after the object is reachable.
+
+**Alternatives considered**:
+
+- Rely on old default grants: rejected because they are no longer reliable for new public tables.
+- Hide all tables in a custom schema immediately: rejected because the feature can be secured cleanly in `public` with explicit grants and policies.
+
+## Decision 6: Keep policy logic simple and index-backed
+
+**Decision**: Use `auth.uid()`-based `EXISTS` checks over indexed `account_id` and `session_id` columns, and wrap direct `auth.uid()` references in `select` where the policy can benefit from per-statement caching.
+
+**Rationale**: RLS is evaluated for every row that is considered, so the policy expressions must stay cheap. Indexed lookups on `profiles.account_id`, `settings.account_id`, `friendships.requester_account_id`, `friendships.addressee_account_id`, and the room membership columns are sufficient for this feature.
+
+**Alternatives considered**:
+
+- Security-definer helper functions in `public`: rejected because exposed-schema helper functions complicate the security surface.
+- Broad joins inside policies: rejected because they are harder to read and can be more expensive on large tables.
+
+## Decision 7: Validate with pgTAP fixtures inside rolled-back SQL transactions
+
+**Decision**: Use pgTAP tests to seed `auth.users`, create matching `accounts` rows, and assert both allowed and denied access paths under authenticated and unauthorized contexts.
+
+**Rationale**: This feature is database-first and security-sensitive. pgTAP gives the clearest evidence that grants, RLS, and policy boundaries behave as intended without involving browser or mobile login flows.
+
+**Alternatives considered**:
+
+- End-to-end UI login tests: rejected because there is no new UI flow in this slice.
+- Service-role-only assertions: rejected because they would bypass the policies being validated.

--- a/specs/008-add-data-rls/spec.md
+++ b/specs/008-add-data-rls/spec.md
@@ -1,0 +1,126 @@
+# Feature Specification: Protected Multiplayer Data Access
+
+**Feature Branch**: `[125-us22-add-row-level-security-for-profiles-friendships-settings-and-room-data]`  
+**Created**: 2026-05-09  
+**Status**: Draft  
+**Input**: User description: "Plan implementation for issue #125 '[US2.2] Add row-level security for profiles, friendships, settings, and room data' using epic #115 and the existing multiplayer schema context."
+
+## Clarifications
+
+### Session 2026-05-09
+
+- Q: Should this story add the missing social/settings tables now, or only add RLS to whatever already exists? → A: Add the minimal profiles, friendships, and settings tables now, then apply RLS to them and the existing room tables.
+- Q: Should friendship records use a request-based lifecycle or a simple accepted-friends list? → A: Use a request-based lifecycle with pending, accepted, declined, and canceled states.
+- Q: Should profile records be self-only or visible to other signed-in users? → A: Visible to friendship participants, with read access expanding after a relationship is accepted.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Personal Records Respect Friendship Boundaries (Priority: P1)
+
+As a signed-in player, I can read and update my own profile and settings records, and accepted friends can read my profile but not my settings, so my private data and preferences stay under my control.
+
+**Why this priority**: Personal identity and preference data is the smallest, clearest security boundary. If this fails, the multiplayer platform leaks private user data immediately.
+
+**Independent Test**: Sign in as two different users, confirm each user can read and update their own profile and settings records, confirm an accepted friend can read the profile but not the settings, and confirm unrelated users cannot access either record.
+
+**Acceptance Scenarios (Gherkin style)**:
+
+1. **Given** a signed-in player with profile and settings records, **When** that player loads their own account data, **Then** they receive their own profile and settings records.
+2. **Given** an accepted friendship between two players, **When** one player loads the other player's profile, **Then** the profile is readable but the settings record remains inaccessible.
+3. **Given** a signed-in player, **When** they try to update another player's private profile or settings data, **Then** the change is rejected and no unauthorized record is modified.
+
+---
+
+### User Story 2 - Social And Room Data Is Shared Only With Authorized Members (Priority: P1)
+
+As a multiplayer player, I can see friendship records I am part of and room data for sessions I belong to, so collaboration works without exposing unrelated relationships or rooms.
+
+**Why this priority**: The multiplayer product depends on shared room visibility, but that visibility must stop at the room boundary and the relationship boundary.
+
+**Independent Test**: Create multiple users, at least one friendship, and at least two rooms with different memberships. Confirm only the involved friendship accounts can read the friendship record, and only room hosts or participants can read the matching room snapshot.
+
+**Acceptance Scenarios (Gherkin style)**:
+
+1. **Given** a friendship record between two players, **When** either involved player loads their friendship data, **Then** they can see that relationship and an unrelated player cannot.
+2. **Given** a room with a host and participants, **When** the host or a current participant loads that room's data, **Then** they can read the session, participant, match, assignment, and event records for that room only.
+3. **Given** a signed-in player who is not part of a room, **When** they query that room's data, **Then** they receive no accessible room records.
+
+---
+
+### User Story 3 - Protected Gameplay Writes Stay Behind Approved Actions (Priority: P2)
+
+As a host or participant, I can rely on approved multiplayer actions while unsafe direct data writes stay blocked, so room state cannot be tampered with through unrestricted client access.
+
+**Why this priority**: Read isolation is not enough if clients can still mutate protected room state directly. The feature must preserve trusted write paths and reject unsafe ones.
+
+**Independent Test**: Attempt direct client-style writes against protected room and gameplay records from both authorized and unauthorized users. Confirm unauthorized direct writes fail while approved room actions continue to work through the intended command surface.
+
+**Acceptance Scenarios (Gherkin style)**:
+
+1. **Given** protected gameplay and room-state records, **When** a client attempts an unauthorized direct write, **Then** the write is rejected and no partial state change is stored.
+2. **Given** an authorized host or participant using an approved multiplayer action, **When** that action is valid for the room and actor, **Then** the change succeeds without granting unrestricted table access.
+
+---
+
+### Edge Cases
+
+- A signed-in player belongs to one room and tries to read data for another active room.
+- A friendship is pending, accepted, declined, or canceled, and only the allowed actor for that state transition may change it.
+- A completed room remains readable to authorized members but does not allow new direct gameplay mutations.
+- A guest or reconnecting participant joins through the room flow without gaining access to unrelated account-private records.
+- A host who owns one room cannot use that ownership to access another host's room data.
+
+## Platform & State Impact _(mandatory when applicable)_
+
+- **Platform Behavior**: No new end-user screen is required for this feature. Native and web clients should observe the same access boundaries once they connect to the shared multiplayer data store.
+- **Shared State Model**: The cloud multiplayer store remains the canonical source of truth for shared room data and the new account-linked profile, friendship, and settings records. Direct client reads must follow account ownership, accepted-friend profile visibility, and room membership rules, while privileged state changes remain on approved action paths.
+- **Identity Model**: Authenticated accounts own personal records. Accepted friendship participants may read profile records, but settings remain owner-only. Room data is readable only when the caller is the room host or a current participant. Guests continue to rely on controlled room join and reclaim flows rather than broad account-level access.
+- **Migration / Backfill**: Existing room data must remain intact while access rules are introduced. This story adds the minimal account-linked profile, friendship, and settings records when they are not already present, then applies RLS to them and the existing room tables without changing prior session history semantics.
+
+## Delivery & Automation Impact _(mandatory)_
+
+- **Unit Test Coverage**: Add automated database access-rule tests that verify allowed and denied reads and writes for personal records, friendship transitions, room membership reads, and blocked direct gameplay writes.
+- **E2E Test Coverage**: No new end-to-end UI coverage is required unless this story also introduces a new client-facing multiplayer data flow. The primary validation for this story lives at the database policy level.
+- **Applicable Skills**: supabase, database-testing, supabase-postgres-best-practices
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The system MUST enable row-level security and enforce row-level access rules on every authenticated-client-exposed record group involved in personal data, friendships, and multiplayer room data.
+- **FR-002**: The system MUST allow a signed-in user to read and update their own profile record, and allow accepted friendship participants to read that profile record.
+- **FR-003**: The system MUST allow a signed-in user to create or update only their own personal settings record.
+- **FR-004**: The system MUST prevent a signed-in user from directly mutating another user's profile or settings records, and must prevent access to another user's profile or settings records unless the caller is the owner or an accepted friendship participant for profile reads.
+- **FR-005**: The system MUST maintain bilateral friendship records anchored to two authenticated accounts and a request-based relationship state.
+- **FR-006**: The system MUST allow only the two accounts involved in a friendship to read that friendship record.
+- **FR-007**: The system MUST allow only the actor permitted by the current friendship lifecycle state to create, accept, decline, cancel, or end that friendship relationship.
+- **FR-008**: The system MUST allow only the host and current participants of a room to read that room's session, participant, match, assignment, and gameplay records.
+- **FR-009**: The system MUST prevent a signed-in user from reading room records for sessions they do not host or participate in.
+- **FR-010**: The system MUST reject direct client writes to protected room-state and gameplay records when the caller is not authorized for that specific action.
+- **FR-011**: The system MUST preserve approved multiplayer action paths for room creation, joining, setup persistence, gameplay updates, and session completion without requiring unrestricted direct table access.
+- **FR-012**: The system MUST provide automated verification for both permitted and rejected access patterns across personal records, friendship records, and room data.
+- **FR-013**: The system MUST introduce the minimal account-linked profile, settings, and friendship records needed to enforce these access boundaries when those records are not already present.
+
+### Key Entities _(include if feature involves data)_
+
+- **Profile**: The account-owned personal identity record a signed-in user may manage for themselves and that accepted friendship participants may read.
+- **Settings**: The account-owned private preference record that only its owner may manage directly.
+- **Friendship**: A bilateral relationship between two authenticated accounts with a request-based lifecycle state such as pending, accepted, declined, or canceled.
+- **Room Membership**: The host or participant relationship that grants visibility into one multiplayer room.
+- **Room Snapshot**: The full set of room-scoped session, participant, match, assignment, and gameplay records visible to authorized room members.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: In 100% of validation scenarios, a signed-in user can read and update their own profile and settings records, and accepted friendship participants can read the profile record without accessing settings or unrelated private records.
+- **SC-002**: In 100% of validation scenarios, only the two accounts involved in a friendship can view that friendship record, and unauthorized users receive no accessible friendship data.
+- **SC-003**: In 100% of validation scenarios, room hosts and participants can load only the room data for sessions they belong to, and unrelated room queries return no accessible records.
+- **SC-004**: In 100% of validation scenarios, unauthorized direct client writes to protected room-state or gameplay records are rejected without leaving partial data changes behind.
+- **SC-005**: The automated access-rule validation suite passes locally for allowed and denied cases covering personal records, friendship records, and room data before the feature is considered complete.
+
+## Assumptions
+
+- The existing authenticated account identity remains the durable owner anchor for personal, friendship, and room-scoped access rules.
+- Guest players continue to rely on controlled join and reclaim flows for room participation rather than broad direct access to account-private records.
+- Read-optimized history, comparison, and leaderboard models remain part of the separate follow-up story in epic #115.

--- a/specs/008-add-data-rls/tasks.md
+++ b/specs/008-add-data-rls/tasks.md
@@ -1,0 +1,184 @@
+# Tasks: Protected Multiplayer Data Access
+
+**Input**: Design documents from `/specs/008-add-data-rls/`
+**Prerequisites**: `plan.md` (required), `spec.md` (required for user stories), `research.md`, `data-model.md`, `contracts/`
+
+**Tests**: This feature requires pgTAP coverage for database access boundaries. Every new behavior introduced by the schema or policies must have corresponding database tests. No end-to-end UI coverage is required because the feature stays in the database layer.
+
+**Organization**: Tasks are grouped by user story so each slice can be implemented and validated independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to, for example `US1`, `US2`, or `US3`
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the file scaffolds for the new database security slice.
+
+- [x] T001 [P] Create the migration scaffolds in `supabase/migrations/011_create_social_tables.sql`, `supabase/migrations/012_social_constraints_and_indexes.sql`, `supabase/migrations/013_enable_rls_and_grants.sql`, `supabase/migrations/014_profiles_rls.sql`, `supabase/migrations/015_settings_rls.sql`, `supabase/migrations/016_friendships_rls.sql`, and `supabase/migrations/017_room_read_rls.sql`
+- [x] T002 [P] Create the pgTAP test scaffolds in `supabase/tests/database/030_profiles_settings_rls.test.sql`, `supabase/tests/database/040_friendships_rls.test.sql`, `supabase/tests/database/050_room_rls.test.sql`, and `supabase/tests/database/060_privileged_write_paths.test.sql`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Define the new account-linked tables, enforce core constraints, and establish the exposed-table RLS/grant posture required by every user story.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [x] T003 Add the `friendship_status` enum plus the `profiles`, `settings`, and `friendships` base tables in `supabase/migrations/011_create_social_tables.sql`
+- [x] T004 Add ownership, uniqueness, and supporting indexes and constraints for `profiles`, `settings`, and `friendships` in `supabase/migrations/012_social_constraints_and_indexes.sql`
+- [x] T005 Add explicit grants and enable RLS on `profiles`, `settings`, `friendships`, and the existing room tables in `supabase/migrations/013_enable_rls_and_grants.sql`, keeping room tables read-only for authenticated clients while service_role retains the approved write path
+
+**Checkpoint**: The social tables exist, the base constraints are in place, and the exposed tables are ready for policy-specific user story work.
+
+---
+
+## Phase 3: User Story 1 - Personal Records Respect Friendship Boundaries (Priority: P1)
+
+**Goal**: Signed-in users can manage their own profile and settings records, and accepted friends can read the profile row but not the settings row.
+
+**Independent Test**: Authenticate as two users, verify each user can read and update their own profile and settings rows, confirm an accepted friend can read the profile but not the settings, and confirm unrelated users cannot access either record.
+
+### Tests for User Story 1 (REQUIRED coverage) ⚠️
+
+- [x] T006 [P] [US1] Extend `supabase/tests/database/010_schema.test.sql` and `supabase/tests/database/020_constraints.test.sql` with `profiles` and `settings` table-shape, ownership, and one-row-per-account assertions
+- [x] T007 [P] [US1] Build `supabase/tests/database/030_profiles_settings_rls.test.sql` to verify owner read/write access, accepted-friend profile visibility, and denied settings access
+
+### Implementation for User Story 1
+
+- [x] T008 [P] [US1] Add owner and accepted-friend RLS policies for `profiles` in `supabase/migrations/014_profiles_rls.sql`
+- [x] T009 [P] [US1] Add owner-only RLS policies for `settings` in `supabase/migrations/015_settings_rls.sql`
+
+**Checkpoint**: User Story 1 is independently testable — profile visibility and settings privacy behave correctly for owners and accepted friends.
+
+---
+
+## Phase 4: User Story 2 - Social And Room Data Is Shared Only With Authorized Members (Priority: P1)
+
+**Goal**: Friendship rows are visible only to the two involved accounts, and room data is visible only to the host and current participants of the session.
+
+**Independent Test**: Create multiple users, at least one friendship, and at least two rooms with different memberships. Confirm only the involved friendship accounts can read the friendship row, and only room hosts or participants can read the matching room snapshot.
+
+### Tests for User Story 2 (REQUIRED coverage) ⚠️
+
+- [x] T010 [P] [US2] Extend `supabase/tests/database/020_constraints.test.sql` with friendship lifecycle, unordered-pair uniqueness, and requester/addressee ownership assertions
+- [x] T011 [P] [US2] Create `supabase/tests/database/040_friendships_rls.test.sql` to verify requester/addressee reads and denied third-party access to friendship rows
+- [x] T012 [P] [US2] Create `supabase/tests/database/050_room_rls.test.sql` to verify host/participant reads and unrelated-user denial across `game_sessions`, `participants`, `matches`, `assignments`, and `gameplay_events`
+
+### Implementation for User Story 2
+
+- [x] T013 [P] [US2] Add requester/addressee `SELECT` and lifecycle-transition RLS policies for `friendships` in `supabase/migrations/016_friendships_rls.sql`
+- [x] T014 [P] [US2] Add host/participant `SELECT` RLS policies for `game_sessions`, `participants`, `matches`, `assignments`, and `gameplay_events` in `supabase/migrations/017_room_read_rls.sql`
+
+**Checkpoint**: User Story 2 is independently testable — friendship access stays bilateral and room reads stay scoped to the correct session members.
+
+---
+
+## Phase 5: User Story 3 - Protected Gameplay Writes Stay Behind Approved Actions (Priority: P2)
+
+**Goal**: Unsafe direct room writes are blocked, while the approved privileged write path remains available for room mutations.
+
+**Independent Test**: Attempt direct client-style inserts, updates, and deletes against protected room tables and confirm they fail, then confirm the approved service-role or validated RPC path still works for the same room mutations.
+
+### Tests for User Story 3 (REQUIRED coverage) ⚠️
+
+- [x] T015 [P] [US3] Add direct-write rejection assertions to `supabase/tests/database/060_privileged_write_paths.test.sql` for authenticated inserts, updates, and deletes against protected room tables
+- [x] T016 [P] [US3] Add approved-path smoke checks to `supabase/tests/database/060_privileged_write_paths.test.sql` to confirm the service-role or validated RPC path still performs the intended room mutations
+
+**Checkpoint**: User Story 3 is independently testable — direct client room writes fail, and the approved mutation path still works.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation, smoke-check verification, and cleanup.
+
+- [x] T017 [P] Run `npx supabase db reset` and `npx supabase test db` against `supabase/migrations/` and `supabase/tests/database/` to validate the full RLS and grant chain
+- [x] T018 [P] Walk the schema smoke checklist in `specs/008-add-data-rls/quickstart.md` and confirm the profile, friendship, settings, and room access boundaries match the spec
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - blocks all user stories
+- **User Stories (Phase 3+)**: Each depends on Foundational completion; US1 and US2 can run in parallel, and US3 can run once the room grants and base RLS posture are in place
+- **Polish (Final Phase)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational - no dependency on US2 or US3
+- **User Story 2 (P1)**: Can start after Foundational - independent of US1, though it shares the friendship table created in Phase 2
+- **User Story 3 (P2)**: Can start after Foundational - independent of US1 and US2 once the room-table grant posture is in place
+
+### Within Each User Story
+
+- Tests MUST be added before or alongside the implementation they validate
+- Table and enum definitions come before policy files that depend on them
+- Different policy files can be worked on in parallel when they do not share the same migration file
+- Each story should be validated independently before moving to the next priority slice
+
+### Parallel Opportunities
+
+- **Phase 1**: T001 and T002 can run in parallel
+- **Phase 3**: T006 and T007 can run in parallel; T008 and T009 can run in parallel
+- **Phase 4**: T010, T011, and T012 can run in parallel; T013 and T014 can run in parallel
+- **Phase 5**: T015 and T016 can run in parallel
+- **Phase 6**: T017 and T018 can run in parallel
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Validate profile and settings access independently before moving on
+
+### Incremental Delivery
+
+1. Finish Setup + Foundational so the schema and RLS posture exist
+2. Deliver User Story 1 to secure profile and settings access
+3. Deliver User Story 2 to secure friendship and room reads
+4. Deliver User Story 3 to prove direct room writes are blocked and the approved mutation path still works
+5. Run the quickstart smoke checklist and the full pgTAP suite before merge
+
+### Parallel Team Strategy
+
+With multiple contributors:
+
+1. Split Setup and Foundational file creation early
+2. After Phase 2, assign one contributor to US1 policies/tests, one to US2 policies/tests, and one to US3 validation
+3. Validate each user story independently as soon as its tests and policies are complete
+
+---
+
+## Summary
+
+| Phase                             | Story | Tasks         | Parallel Opportunities          |
+| --------------------------------- | ----- | ------------- | ------------------------------- |
+| 1 - Setup                         | -     | T001-T002 (2) | T001 + T002                     |
+| 2 - Foundational                  | -     | T003-T005 (3) | T004                            |
+| 3 - US1 Profile and Settings      | P1    | T006-T009 (4) | T006 + T007, T008 + T009        |
+| 4 - US2 Friendship and Room Reads | P1    | T010-T014 (5) | T010 + T011 + T012, T013 + T014 |
+| 5 - US3 Protected Writes          | P2    | T015-T016 (2) | T015 + T016                     |
+| 6 - Polish                        | -     | T017-T018 (2) | T017 + T018                     |
+| **Total**                         |       | **18**        |                                 |
+
+---
+
+## Notes
+
+- [P] tasks can be executed in parallel when they touch different files and do not depend on incomplete work
+- Each story is independently testable once its tasks are complete
+- Features affecting auth or persisted data must include migration, policy, and database validation tasks
+- Keep the approved room mutation path intact; this feature only hardens access boundaries around it

--- a/supabase/migrations/011_create_social_tables.sql
+++ b/supabase/migrations/011_create_social_tables.sql
@@ -1,0 +1,35 @@
+-- 011_create_social_tables.sql
+-- Add the minimal social and settings tables required for RLS-backed access control.
+DO $$ BEGIN IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type
+    WHERE typname = 'friendship_status'
+) THEN CREATE TYPE friendship_status AS ENUM ('pending', 'accepted', 'declined', 'canceled');
+END IF;
+END;
+$$;
+CREATE TABLE IF NOT EXISTS public.profiles (
+    account_id uuid PRIMARY KEY REFERENCES public.accounts(id) ON DELETE CASCADE,
+    display_name text NOT NULL,
+    avatar_url text,
+    bio text,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT chk_profiles_display_name_nonempty CHECK (length(btrim(display_name)) > 0)
+);
+CREATE TABLE IF NOT EXISTS public.settings (
+    account_id uuid PRIMARY KEY REFERENCES public.accounts(id) ON DELETE CASCADE,
+    settings_data jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE TABLE IF NOT EXISTS public.friendships (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    requester_account_id uuid NOT NULL REFERENCES public.accounts(id) ON DELETE CASCADE,
+    addressee_account_id uuid NOT NULL REFERENCES public.accounts(id) ON DELETE CASCADE,
+    status friendship_status NOT NULL DEFAULT 'pending',
+    requested_at timestamptz NOT NULL DEFAULT now(),
+    responded_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+);

--- a/supabase/migrations/012_social_constraints_and_indexes.sql
+++ b/supabase/migrations/012_social_constraints_and_indexes.sql
@@ -1,0 +1,18 @@
+-- 012_social_constraints_and_indexes.sql
+-- Add supporting constraints and indexes for profile, settings, and friendship access paths.
+ALTER TABLE public.friendships
+ADD CONSTRAINT chk_friendships_distinct_accounts CHECK (requester_account_id <> addressee_account_id);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_friendships_account_pair ON public.friendships (
+    LEAST(requester_account_id, addressee_account_id),
+    GREATEST(requester_account_id, addressee_account_id)
+);
+CREATE INDEX IF NOT EXISTS idx_friendships_requester_status_addressee ON public.friendships (
+    requester_account_id,
+    status,
+    addressee_account_id
+);
+CREATE INDEX IF NOT EXISTS idx_friendships_addressee_status_requester ON public.friendships (
+    addressee_account_id,
+    status,
+    requester_account_id
+);

--- a/supabase/migrations/013_enable_rls_and_grants.sql
+++ b/supabase/migrations/013_enable_rls_and_grants.sql
@@ -1,0 +1,90 @@
+-- 013_enable_rls_and_grants.sql
+-- Explicit grants plus RLS enablement for personal, social, and room data surfaces.
+REVOKE ALL ON TABLE public.profiles
+FROM anon,
+    authenticated;
+GRANT SELECT,
+    INSERT,
+    UPDATE ON TABLE public.profiles TO authenticated;
+GRANT SELECT,
+    INSERT,
+    UPDATE,
+    DELETE ON TABLE public.profiles TO service_role;
+REVOKE ALL ON TABLE public.settings
+FROM anon,
+    authenticated;
+GRANT SELECT,
+    INSERT,
+    UPDATE ON TABLE public.settings TO authenticated;
+GRANT SELECT,
+    INSERT,
+    UPDATE,
+    DELETE ON TABLE public.settings TO service_role;
+REVOKE ALL ON TABLE public.friendships
+FROM anon,
+    authenticated;
+GRANT SELECT,
+    INSERT ON TABLE public.friendships TO authenticated;
+GRANT UPDATE (status, responded_at) ON TABLE public.friendships TO authenticated;
+GRANT SELECT,
+    INSERT,
+    UPDATE,
+    DELETE ON TABLE public.friendships TO service_role;
+REVOKE ALL ON TABLE public.game_sessions
+FROM anon,
+    authenticated;
+GRANT SELECT ON TABLE public.game_sessions TO authenticated;
+GRANT SELECT,
+    INSERT,
+    UPDATE,
+    DELETE ON TABLE public.game_sessions TO service_role;
+REVOKE ALL ON TABLE public.participants
+FROM anon,
+    authenticated;
+GRANT SELECT ON TABLE public.participants TO authenticated;
+GRANT SELECT,
+    INSERT,
+    UPDATE,
+    DELETE ON TABLE public.participants TO service_role;
+REVOKE ALL ON TABLE public.matches
+FROM anon,
+    authenticated;
+GRANT SELECT ON TABLE public.matches TO authenticated;
+GRANT SELECT,
+    INSERT,
+    UPDATE,
+    DELETE ON TABLE public.matches TO service_role;
+REVOKE ALL ON TABLE public.assignments
+FROM anon,
+    authenticated;
+GRANT SELECT ON TABLE public.assignments TO authenticated;
+GRANT SELECT,
+    INSERT,
+    UPDATE,
+    DELETE ON TABLE public.assignments TO service_role;
+REVOKE ALL ON TABLE public.gameplay_events
+FROM anon,
+    authenticated;
+GRANT SELECT ON TABLE public.gameplay_events TO authenticated;
+GRANT SELECT,
+    INSERT,
+    UPDATE,
+    DELETE ON TABLE public.gameplay_events TO service_role;
+REVOKE ALL ON FUNCTION public.allocate_event_sequence(uuid)
+FROM PUBLIC,
+    anon,
+    authenticated;
+GRANT EXECUTE ON FUNCTION public.allocate_event_sequence(uuid) TO service_role;
+REVOKE ALL ON FUNCTION public.prevent_events_on_completed()
+FROM PUBLIC,
+    anon,
+    authenticated;
+GRANT EXECUTE ON FUNCTION public.prevent_events_on_completed() TO service_role;
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.friendships ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.game_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.participants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.matches ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.assignments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gameplay_events ENABLE ROW LEVEL SECURITY;

--- a/supabase/migrations/014_profiles_rls.sql
+++ b/supabase/migrations/014_profiles_rls.sql
@@ -1,0 +1,46 @@
+-- 014_profiles_rls.sql
+-- Owner-managed profile access plus accepted-friend profile visibility.
+DROP POLICY IF EXISTS profiles_owner_or_friend_select ON public.profiles;
+CREATE POLICY profiles_owner_or_friend_select ON public.profiles FOR
+SELECT TO authenticated USING (
+        account_id = (
+            SELECT auth.uid()
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM public.friendships
+            WHERE status = 'accepted'
+                AND (
+                    (
+                        requester_account_id = public.profiles.account_id
+                        AND addressee_account_id = (
+                            SELECT auth.uid()
+                        )
+                    )
+                    OR (
+                        addressee_account_id = public.profiles.account_id
+                        AND requester_account_id = (
+                            SELECT auth.uid()
+                        )
+                    )
+                )
+        )
+    );
+DROP POLICY IF EXISTS profiles_owner_insert ON public.profiles;
+CREATE POLICY profiles_owner_insert ON public.profiles FOR
+INSERT TO authenticated WITH CHECK (
+        account_id = (
+            SELECT auth.uid()
+        )
+    );
+DROP POLICY IF EXISTS profiles_owner_update ON public.profiles;
+CREATE POLICY profiles_owner_update ON public.profiles FOR
+UPDATE TO authenticated USING (
+        account_id = (
+            SELECT auth.uid()
+        )
+    ) WITH CHECK (
+        account_id = (
+            SELECT auth.uid()
+        )
+    );

--- a/supabase/migrations/015_settings_rls.sql
+++ b/supabase/migrations/015_settings_rls.sql
@@ -1,0 +1,27 @@
+-- 015_settings_rls.sql
+-- Owner-only settings access.
+DROP POLICY IF EXISTS settings_owner_select ON public.settings;
+CREATE POLICY settings_owner_select ON public.settings FOR
+SELECT TO authenticated USING (
+        account_id = (
+            SELECT auth.uid()
+        )
+    );
+DROP POLICY IF EXISTS settings_owner_insert ON public.settings;
+CREATE POLICY settings_owner_insert ON public.settings FOR
+INSERT TO authenticated WITH CHECK (
+        account_id = (
+            SELECT auth.uid()
+        )
+    );
+DROP POLICY IF EXISTS settings_owner_update ON public.settings;
+CREATE POLICY settings_owner_update ON public.settings FOR
+UPDATE TO authenticated USING (
+        account_id = (
+            SELECT auth.uid()
+        )
+    ) WITH CHECK (
+        account_id = (
+            SELECT auth.uid()
+        )
+    );

--- a/supabase/migrations/016_friendships_rls.sql
+++ b/supabase/migrations/016_friendships_rls.sql
@@ -1,0 +1,74 @@
+-- 016_friendships_rls.sql
+-- Bilateral friendship visibility plus later lifecycle transitions.
+DROP POLICY IF EXISTS friendships_participants_select ON public.friendships;
+CREATE POLICY friendships_participants_select ON public.friendships FOR
+SELECT TO authenticated USING (
+        requester_account_id = (
+            SELECT auth.uid()
+        )
+        OR addressee_account_id = (
+            SELECT auth.uid()
+        )
+    );
+DROP POLICY IF EXISTS friendships_requester_insert ON public.friendships;
+CREATE POLICY friendships_requester_insert ON public.friendships FOR
+INSERT TO authenticated WITH CHECK (
+        requester_account_id = (
+            SELECT auth.uid()
+        )
+        AND requester_account_id <> addressee_account_id
+        AND status = 'pending'
+        AND responded_at IS NULL
+    );
+DROP POLICY IF EXISTS friendships_requester_cancel_pending ON public.friendships;
+CREATE POLICY friendships_requester_cancel_pending ON public.friendships FOR
+UPDATE TO authenticated USING (
+        requester_account_id = (
+            SELECT auth.uid()
+        )
+        AND status = 'pending'
+    ) WITH CHECK (
+        requester_account_id = (
+            SELECT auth.uid()
+        )
+        AND status = 'canceled'
+        AND responded_at IS NOT NULL
+    );
+DROP POLICY IF EXISTS friendships_addressee_respond_pending ON public.friendships;
+CREATE POLICY friendships_addressee_respond_pending ON public.friendships FOR
+UPDATE TO authenticated USING (
+        addressee_account_id = (
+            SELECT auth.uid()
+        )
+        AND status = 'pending'
+    ) WITH CHECK (
+        addressee_account_id = (
+            SELECT auth.uid()
+        )
+        AND status IN ('accepted', 'declined')
+        AND responded_at IS NOT NULL
+    );
+DROP POLICY IF EXISTS friendships_participants_cancel_accepted ON public.friendships;
+CREATE POLICY friendships_participants_cancel_accepted ON public.friendships FOR
+UPDATE TO authenticated USING (
+        status = 'accepted'
+        AND (
+            requester_account_id = (
+                SELECT auth.uid()
+            )
+            OR addressee_account_id = (
+                SELECT auth.uid()
+            )
+        )
+    ) WITH CHECK (
+        status = 'canceled'
+        AND responded_at IS NOT NULL
+        AND (
+            requester_account_id = (
+                SELECT auth.uid()
+            )
+            OR addressee_account_id = (
+                SELECT auth.uid()
+            )
+        )
+    );

--- a/supabase/migrations/017_room_read_rls.sql
+++ b/supabase/migrations/017_room_read_rls.sql
@@ -1,0 +1,54 @@
+-- 017_room_read_rls.sql
+-- Host and current-participant read access for room snapshot tables.
+CREATE SCHEMA IF NOT EXISTS private;
+REVOKE ALL ON SCHEMA private
+FROM PUBLIC,
+    anon,
+    authenticated;
+GRANT USAGE ON SCHEMA private TO authenticated,
+    service_role;
+CREATE OR REPLACE FUNCTION private.can_access_session(p_session_id uuid) RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = '' AS $$
+SELECT EXISTS (
+        SELECT 1
+        FROM public.game_sessions
+        WHERE id = p_session_id
+            AND host_account_id = auth.uid()
+    )
+    OR EXISTS (
+        SELECT 1
+        FROM public.participants
+        WHERE session_id = p_session_id
+            AND account_id = auth.uid()
+    );
+$$;
+REVOKE ALL ON FUNCTION private.can_access_session(uuid)
+FROM PUBLIC,
+    anon;
+GRANT EXECUTE ON FUNCTION private.can_access_session(uuid) TO authenticated,
+    service_role;
+DROP POLICY IF EXISTS game_sessions_room_members_select ON public.game_sessions;
+CREATE POLICY game_sessions_room_members_select ON public.game_sessions FOR
+SELECT TO authenticated USING (
+        private.can_access_session(public.game_sessions.id)
+    );
+DROP POLICY IF EXISTS participants_room_members_select ON public.participants;
+CREATE POLICY participants_room_members_select ON public.participants FOR
+SELECT TO authenticated USING (
+        private.can_access_session(public.participants.session_id)
+    );
+DROP POLICY IF EXISTS matches_room_members_select ON public.matches;
+CREATE POLICY matches_room_members_select ON public.matches FOR
+SELECT TO authenticated USING (
+        private.can_access_session(public.matches.session_id)
+    );
+DROP POLICY IF EXISTS assignments_room_members_select ON public.assignments;
+CREATE POLICY assignments_room_members_select ON public.assignments FOR
+SELECT TO authenticated USING (
+        private.can_access_session(public.assignments.session_id)
+    );
+DROP POLICY IF EXISTS gameplay_events_room_members_select ON public.gameplay_events;
+CREATE POLICY gameplay_events_room_members_select ON public.gameplay_events FOR
+SELECT TO authenticated USING (
+        private.can_access_session(public.gameplay_events.session_id)
+    );

--- a/supabase/tests/database/010_schema.test.sql
+++ b/supabase/tests/database/010_schema.test.sql
@@ -2,7 +2,7 @@
 BEGIN;
 CREATE SCHEMA IF NOT EXISTS extensions;
 CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
-SELECT plan(30);
+SELECT plan(34);
 SELECT ok(
         to_regclass('public.accounts') IS NOT NULL,
         'accounts table exists'
@@ -69,6 +69,52 @@ SELECT is(
         ),
         'timestamp with time zone',
         'accounts.updated_at is timestamptz'
+    );
+SELECT ok(
+        to_regclass('public.profiles') IS NOT NULL,
+        'profiles table exists'
+    );
+SELECT is(
+        (
+            SELECT string_agg(
+                    column_name || ':' || (
+                        CASE
+                            WHEN data_type = 'USER-DEFINED' THEN udt_name
+                            ELSE data_type
+                        END
+                    ) || ':' || is_nullable,
+                    ','
+                    ORDER BY ordinal_position
+                )
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+                AND table_name = 'profiles'
+        ),
+        'account_id:uuid:NO,display_name:text:NO,avatar_url:text:YES,bio:text:YES,created_at:timestamp with time zone:NO,updated_at:timestamp with time zone:NO',
+        'profiles columns, types, and nullability match expectations'
+    );
+SELECT ok(
+        to_regclass('public.settings') IS NOT NULL,
+        'settings table exists'
+    );
+SELECT is(
+        (
+            SELECT string_agg(
+                    column_name || ':' || (
+                        CASE
+                            WHEN data_type = 'USER-DEFINED' THEN udt_name
+                            ELSE data_type
+                        END
+                    ) || ':' || is_nullable,
+                    ','
+                    ORDER BY ordinal_position
+                )
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+                AND table_name = 'settings'
+        ),
+        'account_id:uuid:NO,settings_data:jsonb:NO,created_at:timestamp with time zone:NO,updated_at:timestamp with time zone:NO',
+        'settings columns, types, and nullability match expectations'
     );
 SELECT ok(
         to_regclass('public.game_sessions') IS NOT NULL,

--- a/supabase/tests/database/020_constraints.test.sql
+++ b/supabase/tests/database/020_constraints.test.sql
@@ -2,7 +2,7 @@
 BEGIN;
 CREATE SCHEMA IF NOT EXISTS extensions;
 CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
-SELECT plan(15);
+SELECT plan(27);
 SELECT ok(
         EXISTS (
             SELECT 1
@@ -21,6 +21,44 @@ SELECT ok(
                 AND confrelid = 'auth.users'::regclass
         ),
         'accounts.id references auth.users(id)'
+    );
+SELECT ok(
+        EXISTS (
+            SELECT 1
+            FROM pg_constraint
+            WHERE conrelid = 'public.profiles'::regclass
+                AND contype = 'p'
+        ),
+        'profiles has a primary key'
+    );
+SELECT ok(
+        EXISTS (
+            SELECT 1
+            FROM pg_constraint
+            WHERE conrelid = 'public.profiles'::regclass
+                AND contype = 'f'
+                AND confrelid = 'public.accounts'::regclass
+        ),
+        'profiles.account_id references accounts(id)'
+    );
+SELECT ok(
+        EXISTS (
+            SELECT 1
+            FROM pg_constraint
+            WHERE conrelid = 'public.settings'::regclass
+                AND contype = 'p'
+        ),
+        'settings has a primary key'
+    );
+SELECT ok(
+        EXISTS (
+            SELECT 1
+            FROM pg_constraint
+            WHERE conrelid = 'public.settings'::regclass
+                AND contype = 'f'
+                AND confrelid = 'public.accounts'::regclass
+        ),
+        'settings.account_id references accounts(id)'
     );
 SELECT is(
         (
@@ -50,6 +88,20 @@ SELECT is(
         'registered,guest',
         'participant_membership_type enum contains expected values'
     );
+SELECT is(
+        (
+            SELECT string_agg(
+                    e.enumlabel,
+                    ','
+                    ORDER BY e.enumsortorder
+                )
+            FROM pg_enum e
+                JOIN pg_type t ON t.oid = e.enumtypid
+            WHERE t.typname = 'friendship_status'
+        ),
+        'pending,accepted,declined,canceled',
+        'friendship_status enum contains expected values'
+    );
 SELECT ok(
         EXISTS (
             SELECT 1
@@ -69,6 +121,39 @@ SELECT ok(
                 AND pg_get_constraintdef(oid) = 'CHECK (((completed_at IS NULL) OR (state = ''completed''::session_state)))'
         ),
         'game_sessions has the completed_at lifecycle check constraint'
+    );
+SELECT ok(
+        EXISTS (
+            SELECT 1
+            FROM pg_constraint
+            WHERE conrelid = 'public.friendships'::regclass
+                AND contype = 'f'
+                AND confrelid = 'public.accounts'::regclass
+                AND conkey = ARRAY [2]::smallint []
+        ),
+        'friendships.requester_account_id references accounts(id)'
+    );
+SELECT ok(
+        EXISTS (
+            SELECT 1
+            FROM pg_constraint
+            WHERE conrelid = 'public.friendships'::regclass
+                AND contype = 'f'
+                AND confrelid = 'public.accounts'::regclass
+                AND conkey = ARRAY [3]::smallint []
+        ),
+        'friendships.addressee_account_id references accounts(id)'
+    );
+SELECT ok(
+        EXISTS (
+            SELECT 1
+            FROM pg_indexes
+            WHERE schemaname = 'public'
+                AND tablename = 'friendships'
+                AND indexname = 'ux_friendships_account_pair'
+                AND indexdef LIKE 'CREATE UNIQUE INDEX%LEAST(requester_account_id, addressee_account_id), GREATEST(requester_account_id, addressee_account_id)%'
+        ),
+        'friendships has a unique unordered account-pair index'
     );
 CREATE TEMP TABLE phase45_constraint_context AS WITH host_one_auth AS (
     INSERT INTO auth.users (
@@ -274,6 +359,14 @@ event_seed AS (
 )
 SELECT (
         SELECT id
+        FROM host_one_account
+    ) AS host_one_account_id,
+    (
+        SELECT id
+        FROM host_two_account
+    ) AS host_two_account_id,
+    (
+        SELECT id
         FROM session_one
     ) AS session_one_id,
     (
@@ -304,6 +397,128 @@ CREATE TEMP TABLE phase45_constraint_results (
     name text PRIMARY KEY,
     passed boolean NOT NULL
 );
+INSERT INTO public.profiles (account_id, display_name)
+VALUES (
+        (
+            SELECT registered_account_id
+            FROM phase45_constraint_context
+        ),
+        'Registered Profile'
+    );
+INSERT INTO public.settings (account_id, settings_data)
+VALUES (
+        (
+            SELECT registered_account_id
+            FROM phase45_constraint_context
+        ),
+        '{"notifications":true}'::jsonb
+    );
+INSERT INTO public.friendships (
+        requester_account_id,
+        addressee_account_id,
+        status,
+        responded_at
+    )
+VALUES (
+        (
+            SELECT host_one_account_id
+            FROM phase45_constraint_context
+        ),
+        (
+            SELECT registered_account_id
+            FROM phase45_constraint_context
+        ),
+        'accepted',
+        now()
+    );
+DO $$ BEGIN BEGIN
+INSERT INTO public.profiles (account_id, display_name)
+VALUES (
+        (
+            SELECT registered_account_id
+            FROM phase45_constraint_context
+        ),
+        'Duplicate Profile'
+    );
+INSERT INTO phase45_constraint_results
+VALUES ('duplicate_profile_rejected', FALSE);
+EXCEPTION
+WHEN unique_violation THEN
+INSERT INTO phase45_constraint_results
+VALUES ('duplicate_profile_rejected', TRUE);
+END;
+END;
+$$;
+DO $$ BEGIN BEGIN
+INSERT INTO public.settings (account_id, settings_data)
+VALUES (
+        (
+            SELECT registered_account_id
+            FROM phase45_constraint_context
+        ),
+        '{"notifications":false}'::jsonb
+    );
+INSERT INTO phase45_constraint_results
+VALUES ('duplicate_settings_rejected', FALSE);
+EXCEPTION
+WHEN unique_violation THEN
+INSERT INTO phase45_constraint_results
+VALUES ('duplicate_settings_rejected', TRUE);
+END;
+END;
+$$;
+DO $$ BEGIN BEGIN
+INSERT INTO public.friendships (
+        requester_account_id,
+        addressee_account_id,
+        status
+    )
+VALUES (
+        (
+            SELECT registered_account_id
+            FROM phase45_constraint_context
+        ),
+        (
+            SELECT host_one_account_id
+            FROM phase45_constraint_context
+        ),
+        'pending'
+    );
+INSERT INTO phase45_constraint_results
+VALUES ('duplicate_friendship_pair_rejected', FALSE);
+EXCEPTION
+WHEN unique_violation THEN
+INSERT INTO phase45_constraint_results
+VALUES ('duplicate_friendship_pair_rejected', TRUE);
+END;
+END;
+$$;
+DO $$ BEGIN BEGIN
+INSERT INTO public.friendships (
+        requester_account_id,
+        addressee_account_id,
+        status
+    )
+VALUES (
+        (
+            SELECT host_two_account_id
+            FROM phase45_constraint_context
+        ),
+        (
+            SELECT host_two_account_id
+            FROM phase45_constraint_context
+        ),
+        'pending'
+    );
+INSERT INTO phase45_constraint_results
+VALUES ('self_friendship_rejected', FALSE);
+EXCEPTION
+WHEN check_violation THEN
+INSERT INTO phase45_constraint_results
+VALUES ('self_friendship_rejected', TRUE);
+END;
+END;
+$$;
 DO $$ BEGIN BEGIN
 INSERT INTO public.participants (
         session_id,
@@ -565,6 +780,38 @@ SELECT ok(
             WHERE name = 'duplicate_registered_participant'
         ),
         'duplicate registered participant is rejected'
+    );
+SELECT ok(
+        (
+            SELECT passed
+            FROM phase45_constraint_results
+            WHERE name = 'duplicate_profile_rejected'
+        ),
+        'duplicate profile rows for the same account are rejected'
+    );
+SELECT ok(
+        (
+            SELECT passed
+            FROM phase45_constraint_results
+            WHERE name = 'duplicate_settings_rejected'
+        ),
+        'duplicate settings rows for the same account are rejected'
+    );
+SELECT ok(
+        (
+            SELECT passed
+            FROM phase45_constraint_results
+            WHERE name = 'duplicate_friendship_pair_rejected'
+        ),
+        'duplicate unordered friendship pairs are rejected'
+    );
+SELECT ok(
+        (
+            SELECT passed
+            FROM phase45_constraint_results
+            WHERE name = 'self_friendship_rejected'
+        ),
+        'friendships between the same account are rejected'
     );
 SELECT ok(
         (

--- a/supabase/tests/database/030_profiles_settings_rls.test.sql
+++ b/supabase/tests/database/030_profiles_settings_rls.test.sql
@@ -1,0 +1,358 @@
+BEGIN;
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+SELECT plan(10);
+CREATE TEMP TABLE profile_settings_rls_context AS WITH owner_auth AS (
+    INSERT INTO auth.users (
+            id,
+            aud,
+            role,
+            email,
+            email_confirmed_at,
+            created_at,
+            updated_at,
+            raw_app_meta_data,
+            raw_user_meta_data,
+            is_sso_user,
+            is_anonymous
+        )
+    VALUES (
+            gen_random_uuid(),
+            'authenticated',
+            'authenticated',
+            'profile-owner@test.local',
+            now(),
+            now(),
+            now(),
+            '{"provider":"email","providers":["email"]}'::jsonb,
+            '{}'::jsonb,
+            FALSE,
+            FALSE
+        )
+    RETURNING id
+),
+friend_auth AS (
+    INSERT INTO auth.users (
+            id,
+            aud,
+            role,
+            email,
+            email_confirmed_at,
+            created_at,
+            updated_at,
+            raw_app_meta_data,
+            raw_user_meta_data,
+            is_sso_user,
+            is_anonymous
+        )
+    VALUES (
+            gen_random_uuid(),
+            'authenticated',
+            'authenticated',
+            'profile-friend@test.local',
+            now(),
+            now(),
+            now(),
+            '{"provider":"email","providers":["email"]}'::jsonb,
+            '{}'::jsonb,
+            FALSE,
+            FALSE
+        )
+    RETURNING id
+),
+stranger_auth AS (
+    INSERT INTO auth.users (
+            id,
+            aud,
+            role,
+            email,
+            email_confirmed_at,
+            created_at,
+            updated_at,
+            raw_app_meta_data,
+            raw_user_meta_data,
+            is_sso_user,
+            is_anonymous
+        )
+    VALUES (
+            gen_random_uuid(),
+            'authenticated',
+            'authenticated',
+            'profile-stranger@test.local',
+            now(),
+            now(),
+            now(),
+            '{"provider":"email","providers":["email"]}'::jsonb,
+            '{}'::jsonb,
+            FALSE,
+            FALSE
+        )
+    RETURNING id
+),
+owner_account AS (
+    INSERT INTO public.accounts (id, preferred_display_name)
+    SELECT id,
+        'Profile Owner'
+    FROM owner_auth
+    RETURNING id
+),
+friend_account AS (
+    INSERT INTO public.accounts (id, preferred_display_name)
+    SELECT id,
+        'Profile Friend'
+    FROM friend_auth
+    RETURNING id
+),
+stranger_account AS (
+    INSERT INTO public.accounts (id, preferred_display_name)
+    SELECT id,
+        'Profile Stranger'
+    FROM stranger_auth
+    RETURNING id
+),
+owner_profile AS (
+    INSERT INTO public.profiles (account_id, display_name, bio)
+    SELECT id,
+        'Owner Profile',
+        'Owner bio'
+    FROM owner_account
+    RETURNING account_id
+),
+owner_settings AS (
+    INSERT INTO public.settings (account_id, settings_data)
+    SELECT id,
+        '{"theme":"classic"}'::jsonb
+    FROM owner_account
+    RETURNING account_id
+),
+accepted_friendship AS (
+    INSERT INTO public.friendships (
+            requester_account_id,
+            addressee_account_id,
+            status,
+            responded_at
+        )
+    SELECT owner_account.id,
+        friend_account.id,
+        'accepted',
+        now()
+    FROM owner_account,
+        friend_account
+    RETURNING id
+)
+SELECT (
+        SELECT id
+        FROM owner_account
+    ) AS owner_account_id,
+    (
+        SELECT id
+        FROM friend_account
+    ) AS friend_account_id,
+    (
+        SELECT id
+        FROM stranger_account
+    ) AS stranger_account_id,
+    (
+        SELECT id
+        FROM accepted_friendship
+    ) AS friendship_id;
+GRANT SELECT ON TABLE profile_settings_rls_context TO authenticated;
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.role', 'authenticated', true);
+SELECT set_config(
+        'request.jwt.claim.sub',
+        (
+            SELECT owner_account_id::text
+            FROM profile_settings_rls_context
+        ),
+        true
+    );
+SELECT is(
+        (
+            SELECT display_name
+            FROM public.profiles
+            WHERE account_id = (
+                    SELECT owner_account_id
+                    FROM profile_settings_rls_context
+                )
+        ),
+        'Owner Profile',
+        'owner can read the profile row'
+    );
+WITH updated_profile AS (
+    UPDATE public.profiles
+    SET bio = 'Owner bio updated'
+    WHERE account_id = (
+            SELECT owner_account_id
+            FROM profile_settings_rls_context
+        )
+    RETURNING bio
+)
+SELECT is(
+        (
+            SELECT bio
+            FROM updated_profile
+        ),
+        'Owner bio updated',
+        'owner can update the profile row'
+    );
+SELECT set_config(
+        'request.jwt.claim.sub',
+        (
+            SELECT friend_account_id::text
+            FROM profile_settings_rls_context
+        ),
+        true
+    );
+WITH inserted_friend_profile AS (
+    INSERT INTO public.profiles (account_id, display_name, bio)
+    VALUES (
+            (
+                SELECT friend_account_id
+                FROM profile_settings_rls_context
+            ),
+            'Friend Profile',
+            'Friend bio'
+        )
+    RETURNING display_name
+)
+SELECT is(
+        (
+            SELECT display_name
+            FROM inserted_friend_profile
+        ),
+        'Friend Profile',
+        'authenticated owner can insert their own profile row'
+    );
+SELECT is(
+        (
+            SELECT display_name
+            FROM public.profiles
+            WHERE account_id = (
+                    SELECT owner_account_id
+                    FROM profile_settings_rls_context
+                )
+        ),
+        'Owner Profile',
+        'accepted friend can read the owner profile row'
+    );
+SELECT set_config(
+        'request.jwt.claim.sub',
+        (
+            SELECT stranger_account_id::text
+            FROM profile_settings_rls_context
+        ),
+        true
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.profiles
+            WHERE account_id = (
+                    SELECT owner_account_id
+                    FROM profile_settings_rls_context
+                )
+        ),
+        '0',
+        'unrelated user cannot read the owner profile row'
+    );
+SELECT set_config(
+        'request.jwt.claim.sub',
+        (
+            SELECT owner_account_id::text
+            FROM profile_settings_rls_context
+        ),
+        true
+    );
+SELECT is(
+        (
+            SELECT settings_data->>'theme'
+            FROM public.settings
+            WHERE account_id = (
+                    SELECT owner_account_id
+                    FROM profile_settings_rls_context
+                )
+        ),
+        'classic',
+        'owner can read the settings row'
+    );
+WITH updated_settings AS (
+    UPDATE public.settings
+    SET settings_data = '{"theme":"night"}'::jsonb
+    WHERE account_id = (
+            SELECT owner_account_id
+            FROM profile_settings_rls_context
+        )
+    RETURNING settings_data->>'theme' AS theme
+)
+SELECT is(
+        (
+            SELECT theme
+            FROM updated_settings
+        ),
+        'night',
+        'owner can update the settings row'
+    );
+SELECT set_config(
+        'request.jwt.claim.sub',
+        (
+            SELECT friend_account_id::text
+            FROM profile_settings_rls_context
+        ),
+        true
+    );
+WITH inserted_friend_settings AS (
+    INSERT INTO public.settings (account_id, settings_data)
+    VALUES (
+            (
+                SELECT friend_account_id
+                FROM profile_settings_rls_context
+            ),
+            '{"volume":5}'::jsonb
+        )
+    RETURNING settings_data->>'volume' AS volume
+)
+SELECT is(
+        (
+            SELECT volume
+            FROM inserted_friend_settings
+        ),
+        '5',
+        'authenticated owner can insert their own settings row'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.settings
+            WHERE account_id = (
+                    SELECT owner_account_id
+                    FROM profile_settings_rls_context
+                )
+        ),
+        '0',
+        'accepted friend cannot read the owner settings row'
+    );
+SELECT set_config(
+        'request.jwt.claim.sub',
+        (
+            SELECT stranger_account_id::text
+            FROM profile_settings_rls_context
+        ),
+        true
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.settings
+            WHERE account_id = (
+                    SELECT owner_account_id
+                    FROM profile_settings_rls_context
+                )
+        ),
+        '0',
+        'unrelated user cannot read the owner settings row'
+    );
+RESET ROLE;
+SELECT *
+FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/040_friendships_rls.test.sql
+++ b/supabase/tests/database/040_friendships_rls.test.sql
@@ -1,0 +1,412 @@
+BEGIN;
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+SELECT plan(9);
+CREATE TEMP TABLE friendships_rls_context AS WITH requester_auth AS (
+    INSERT INTO auth.users (
+            id,
+            aud,
+            role,
+            email,
+            email_confirmed_at,
+            created_at,
+            updated_at,
+            raw_app_meta_data,
+            raw_user_meta_data,
+            is_sso_user,
+            is_anonymous
+        )
+    VALUES (
+            gen_random_uuid(),
+            'authenticated',
+            'authenticated',
+            'friendships-requester@test.local',
+            now(),
+            now(),
+            now(),
+            '{"provider":"email","providers":["email"]}'::jsonb,
+            '{}'::jsonb,
+            FALSE,
+            FALSE
+        )
+    RETURNING id
+),
+addressee_auth AS (
+    INSERT INTO auth.users (
+            id,
+            aud,
+            role,
+            email,
+            email_confirmed_at,
+            created_at,
+            updated_at,
+            raw_app_meta_data,
+            raw_user_meta_data,
+            is_sso_user,
+            is_anonymous
+        )
+    VALUES (
+            gen_random_uuid(),
+            'authenticated',
+            'authenticated',
+            'friendships-addressee@test.local',
+            now(),
+            now(),
+            now(),
+            '{"provider":"email","providers":["email"]}'::jsonb,
+            '{}'::jsonb,
+            FALSE,
+            FALSE
+        )
+    RETURNING id
+),
+outsider_auth AS (
+    INSERT INTO auth.users (
+            id,
+            aud,
+            role,
+            email,
+            email_confirmed_at,
+            created_at,
+            updated_at,
+            raw_app_meta_data,
+            raw_user_meta_data,
+            is_sso_user,
+            is_anonymous
+        )
+    VALUES (
+            gen_random_uuid(),
+            'authenticated',
+            'authenticated',
+            'friendships-outsider@test.local',
+            now(),
+            now(),
+            now(),
+            '{"provider":"email","providers":["email"]}'::jsonb,
+            '{}'::jsonb,
+            FALSE,
+            FALSE
+        )
+    RETURNING id
+),
+fourth_auth AS (
+    INSERT INTO auth.users (
+            id,
+            aud,
+            role,
+            email,
+            email_confirmed_at,
+            created_at,
+            updated_at,
+            raw_app_meta_data,
+            raw_user_meta_data,
+            is_sso_user,
+            is_anonymous
+        )
+    VALUES (
+            gen_random_uuid(),
+            'authenticated',
+            'authenticated',
+            'friendships-fourth@test.local',
+            now(),
+            now(),
+            now(),
+            '{"provider":"email","providers":["email"]}'::jsonb,
+            '{}'::jsonb,
+            FALSE,
+            FALSE
+        )
+    RETURNING id
+),
+requester_account AS (
+    INSERT INTO public.accounts (id, preferred_display_name)
+    SELECT id,
+        'Friendship Requester'
+    FROM requester_auth
+    RETURNING id
+),
+addressee_account AS (
+    INSERT INTO public.accounts (id, preferred_display_name)
+    SELECT id,
+        'Friendship Addressee'
+    FROM addressee_auth
+    RETURNING id
+),
+outsider_account AS (
+    INSERT INTO public.accounts (id, preferred_display_name)
+    SELECT id,
+        'Friendship Outsider'
+    FROM outsider_auth
+    RETURNING id
+),
+fourth_account AS (
+    INSERT INTO public.accounts (id, preferred_display_name)
+    SELECT id,
+        'Friendship Fourth'
+    FROM fourth_auth
+    RETURNING id
+),
+pending_friendship AS (
+    INSERT INTO public.friendships (
+            requester_account_id,
+            addressee_account_id,
+            status
+        )
+    SELECT requester_account.id,
+        addressee_account.id,
+        'pending'
+    FROM requester_account,
+        addressee_account
+    RETURNING id
+),
+unrelated_friendship AS (
+    INSERT INTO public.friendships (
+            requester_account_id,
+            addressee_account_id,
+            status,
+            responded_at
+        )
+    SELECT outsider_account.id,
+        fourth_account.id,
+        'accepted',
+        now()
+    FROM outsider_account,
+        fourth_account
+    RETURNING id
+),
+requester_pending_to_fourth AS (
+    INSERT INTO public.friendships (
+            requester_account_id,
+            addressee_account_id,
+            status
+        )
+    SELECT requester_account.id,
+        fourth_account.id,
+        'pending'
+    FROM requester_account,
+        fourth_account
+    RETURNING id
+)
+SELECT (
+        SELECT id
+        FROM requester_account
+    ) AS requester_account_id,
+    (
+        SELECT id
+        FROM addressee_account
+    ) AS addressee_account_id,
+    (
+        SELECT id
+        FROM outsider_account
+    ) AS outsider_account_id,
+    (
+        SELECT id
+        FROM pending_friendship
+    ) AS pending_friendship_id,
+    (
+        SELECT id
+        FROM unrelated_friendship
+    ) AS unrelated_friendship_id,
+    (
+        SELECT id
+        FROM requester_pending_to_fourth
+    ) AS requester_pending_to_fourth_id;
+GRANT SELECT ON TABLE friendships_rls_context TO authenticated;
+CREATE TEMP TABLE friendships_rls_results (
+    name text PRIMARY KEY,
+    passed boolean NOT NULL
+);
+GRANT SELECT,
+    INSERT ON TABLE friendships_rls_results TO authenticated;
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.role', 'authenticated', true);
+SELECT set_config(
+        'request.jwt.claim.sub',
+        (
+            SELECT requester_account_id::text
+            FROM friendships_rls_context
+        ),
+        true
+    );
+SELECT is(
+        (
+            SELECT status::text
+            FROM public.friendships
+            WHERE id = (
+                    SELECT pending_friendship_id
+                    FROM friendships_rls_context
+                )
+        ),
+        'pending',
+        'requester can read the friendship row'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.friendships
+            WHERE id = (
+                    SELECT unrelated_friendship_id
+                    FROM friendships_rls_context
+                )
+        ),
+        '0',
+        'requester cannot read unrelated friendship rows'
+    );
+WITH inserted_friendship AS (
+    INSERT INTO public.friendships (
+            requester_account_id,
+            addressee_account_id,
+            status
+        )
+    VALUES (
+            (
+                SELECT requester_account_id
+                FROM friendships_rls_context
+            ),
+            (
+                SELECT outsider_account_id
+                FROM friendships_rls_context
+            ),
+            'pending'
+        )
+    RETURNING status::text
+)
+SELECT is(
+        (
+            SELECT status
+            FROM inserted_friendship
+        ),
+        'pending',
+        'requester can insert a pending friendship row'
+    );
+DO $$ BEGIN BEGIN
+UPDATE public.friendships
+SET status = 'accepted',
+    responded_at = now()
+WHERE id = (
+        SELECT requester_pending_to_fourth_id
+        FROM friendships_rls_context
+    );
+INSERT INTO friendships_rls_results
+VALUES ('requester_cannot_accept_own_pending', FALSE);
+EXCEPTION
+WHEN insufficient_privilege THEN
+INSERT INTO friendships_rls_results
+VALUES ('requester_cannot_accept_own_pending', TRUE);
+END;
+END;
+$$;
+SELECT set_config(
+        'request.jwt.claim.sub',
+        (
+            SELECT addressee_account_id::text
+            FROM friendships_rls_context
+        ),
+        true
+    );
+SELECT is(
+        (
+            SELECT status::text
+            FROM public.friendships
+            WHERE id = (
+                    SELECT pending_friendship_id
+                    FROM friendships_rls_context
+                )
+        ),
+        'pending',
+        'addressee can read the friendship row'
+    );
+WITH accepted_friendship AS (
+    UPDATE public.friendships
+    SET status = 'accepted',
+        responded_at = now()
+    WHERE id = (
+            SELECT pending_friendship_id
+            FROM friendships_rls_context
+        )
+    RETURNING status::text
+)
+SELECT is(
+        (
+            SELECT status
+            FROM accepted_friendship
+        ),
+        'accepted',
+        'addressee can accept a pending friendship row'
+    );
+SELECT set_config(
+        'request.jwt.claim.sub',
+        (
+            SELECT requester_account_id::text
+            FROM friendships_rls_context
+        ),
+        true
+    );
+WITH canceled_friendship AS (
+    UPDATE public.friendships
+    SET status = 'canceled',
+        responded_at = now()
+    WHERE id = (
+            SELECT pending_friendship_id
+            FROM friendships_rls_context
+        )
+    RETURNING status::text
+)
+SELECT is(
+        (
+            SELECT status
+            FROM canceled_friendship
+        ),
+        'canceled',
+        'requester can cancel an accepted friendship row'
+    );
+SELECT ok(
+        (
+            SELECT passed
+            FROM friendships_rls_results
+            WHERE name = 'requester_cannot_accept_own_pending'
+        ),
+        'requester cannot accept a friendship they initiated'
+    );
+SELECT set_config(
+        'request.jwt.claim.sub',
+        (
+            SELECT outsider_account_id::text
+            FROM friendships_rls_context
+        ),
+        true
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.friendships
+            WHERE id = (
+                    SELECT pending_friendship_id
+                    FROM friendships_rls_context
+                )
+        ),
+        '0',
+        'third-party accounts cannot read unrelated friendship rows'
+    );
+WITH outsider_update AS (
+    UPDATE public.friendships
+    SET status = 'declined',
+        responded_at = now()
+    WHERE id = (
+            SELECT pending_friendship_id
+            FROM friendships_rls_context
+        )
+    RETURNING id
+)
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM outsider_update
+        ),
+        '0',
+        'third-party accounts cannot update unrelated friendship rows'
+    );
+RESET ROLE;
+SELECT *
+FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/050_room_rls.test.sql
+++ b/supabase/tests/database/050_room_rls.test.sql
@@ -1,0 +1,545 @@
+BEGIN;
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+SELECT plan(15);
+CREATE TEMP TABLE room_rls_context AS WITH host_one_auth AS (
+    INSERT INTO auth.users (
+            id,
+            aud,
+            role,
+            email,
+            email_confirmed_at,
+            created_at,
+            updated_at,
+            raw_app_meta_data,
+            raw_user_meta_data,
+            is_sso_user,
+            is_anonymous
+        )
+    VALUES (
+            gen_random_uuid(),
+            'authenticated',
+            'authenticated',
+            'room-host-1@test.local',
+            now(),
+            now(),
+            now(),
+            '{"provider":"email","providers":["email"]}'::jsonb,
+            '{}'::jsonb,
+            FALSE,
+            FALSE
+        )
+    RETURNING id
+),
+participant_one_auth AS (
+    INSERT INTO auth.users (
+            id,
+            aud,
+            role,
+            email,
+            email_confirmed_at,
+            created_at,
+            updated_at,
+            raw_app_meta_data,
+            raw_user_meta_data,
+            is_sso_user,
+            is_anonymous
+        )
+    VALUES (
+            gen_random_uuid(),
+            'authenticated',
+            'authenticated',
+            'room-participant-1@test.local',
+            now(),
+            now(),
+            now(),
+            '{"provider":"email","providers":["email"]}'::jsonb,
+            '{}'::jsonb,
+            FALSE,
+            FALSE
+        )
+    RETURNING id
+),
+host_two_auth AS (
+    INSERT INTO auth.users (
+            id,
+            aud,
+            role,
+            email,
+            email_confirmed_at,
+            created_at,
+            updated_at,
+            raw_app_meta_data,
+            raw_user_meta_data,
+            is_sso_user,
+            is_anonymous
+        )
+    VALUES (
+            gen_random_uuid(),
+            'authenticated',
+            'authenticated',
+            'room-host-2@test.local',
+            now(),
+            now(),
+            now(),
+            '{"provider":"email","providers":["email"]}'::jsonb,
+            '{}'::jsonb,
+            FALSE,
+            FALSE
+        )
+    RETURNING id
+),
+participant_two_auth AS (
+    INSERT INTO auth.users (
+            id,
+            aud,
+            role,
+            email,
+            email_confirmed_at,
+            created_at,
+            updated_at,
+            raw_app_meta_data,
+            raw_user_meta_data,
+            is_sso_user,
+            is_anonymous
+        )
+    VALUES (
+            gen_random_uuid(),
+            'authenticated',
+            'authenticated',
+            'room-participant-2@test.local',
+            now(),
+            now(),
+            now(),
+            '{"provider":"email","providers":["email"]}'::jsonb,
+            '{}'::jsonb,
+            FALSE,
+            FALSE
+        )
+    RETURNING id
+),
+host_one_account AS (
+    INSERT INTO public.accounts (id, preferred_display_name)
+    SELECT id,
+        'Room Host One'
+    FROM host_one_auth
+    RETURNING id
+),
+participant_one_account AS (
+    INSERT INTO public.accounts (id, preferred_display_name)
+    SELECT id,
+        'Room Participant One'
+    FROM participant_one_auth
+    RETURNING id
+),
+host_two_account AS (
+    INSERT INTO public.accounts (id, preferred_display_name)
+    SELECT id,
+        'Room Host Two'
+    FROM host_two_auth
+    RETURNING id
+),
+participant_two_account AS (
+    INSERT INTO public.accounts (id, preferred_display_name)
+    SELECT id,
+        'Room Participant Two'
+    FROM participant_two_auth
+    RETURNING id
+),
+session_one AS (
+    INSERT INTO public.game_sessions (host_account_id, join_code)
+    SELECT id,
+        'RLS501'
+    FROM host_one_account
+    RETURNING id
+),
+session_two AS (
+    INSERT INTO public.game_sessions (host_account_id, join_code)
+    SELECT id,
+        'RLS502'
+    FROM host_two_account
+    RETURNING id
+),
+participant_one AS (
+    INSERT INTO public.participants (
+            session_id,
+            account_id,
+            display_name,
+            membership_type
+        )
+    SELECT session_one.id,
+        participant_one_account.id,
+        'Participant One',
+        'registered'
+    FROM session_one,
+        participant_one_account
+    RETURNING id
+),
+participant_two AS (
+    INSERT INTO public.participants (
+            session_id,
+            account_id,
+            display_name,
+            membership_type
+        )
+    SELECT session_two.id,
+        participant_two_account.id,
+        'Participant Two',
+        'registered'
+    FROM session_two,
+        participant_two_account
+    RETURNING id
+),
+match_one AS (
+    INSERT INTO public.matches (
+            session_id,
+            source_provider,
+            source_match_id,
+            home_team_name,
+            away_team_name
+        )
+    SELECT session_one.id,
+        'espn',
+        'room-rls-match-1',
+        'Home One',
+        'Away One'
+    FROM session_one
+    RETURNING id
+),
+match_two AS (
+    INSERT INTO public.matches (
+            session_id,
+            source_provider,
+            source_match_id,
+            home_team_name,
+            away_team_name
+        )
+    SELECT session_two.id,
+        'espn',
+        'room-rls-match-2',
+        'Home Two',
+        'Away Two'
+    FROM session_two
+    RETURNING id
+),
+assignment_one AS (
+    INSERT INTO public.assignments (session_id, participant_id, match_id)
+    SELECT session_one.id,
+        participant_one.id,
+        match_one.id
+    FROM session_one,
+        participant_one,
+        match_one
+    RETURNING session_id,
+        participant_id,
+        match_id
+),
+assignment_two AS (
+    INSERT INTO public.assignments (session_id, participant_id, match_id)
+    SELECT session_two.id,
+        participant_two.id,
+        match_two.id
+    FROM session_two,
+        participant_two,
+        match_two
+    RETURNING session_id,
+        participant_id,
+        match_id
+),
+event_one AS (
+    INSERT INTO public.gameplay_events (
+            session_id,
+            sequence_number,
+            actor_participant_id,
+            event_type,
+            idempotency_key,
+            payload
+        )
+    SELECT session_one.id,
+        1,
+        participant_one.id,
+        'participant_joined',
+        'room-rls-event-1',
+        '{}'::jsonb
+    FROM session_one,
+        participant_one
+    RETURNING id
+),
+event_two AS (
+    INSERT INTO public.gameplay_events (
+            session_id,
+            sequence_number,
+            actor_participant_id,
+            event_type,
+            idempotency_key,
+            payload
+        )
+    SELECT session_two.id,
+        1,
+        participant_two.id,
+        'participant_joined',
+        'room-rls-event-2',
+        '{}'::jsonb
+    FROM session_two,
+        participant_two
+    RETURNING id
+)
+SELECT (
+        SELECT id
+        FROM host_one_account
+    ) AS host_one_account_id,
+    (
+        SELECT id
+        FROM participant_one_account
+    ) AS participant_one_account_id,
+    (
+        SELECT id
+        FROM host_two_account
+    ) AS host_two_account_id,
+    (
+        SELECT id
+        FROM participant_two_account
+    ) AS participant_two_account_id,
+    (
+        SELECT id
+        FROM session_one
+    ) AS session_one_id,
+    (
+        SELECT id
+        FROM session_two
+    ) AS session_two_id,
+    (
+        SELECT id
+        FROM participant_one
+    ) AS participant_one_id,
+    (
+        SELECT id
+        FROM participant_two
+    ) AS participant_two_id,
+    (
+        SELECT id
+        FROM match_one
+    ) AS match_one_id,
+    (
+        SELECT id
+        FROM match_two
+    ) AS match_two_id,
+    (
+        SELECT id
+        FROM event_one
+    ) AS event_one_id,
+    (
+        SELECT id
+        FROM event_two
+    ) AS event_two_id;
+GRANT SELECT ON TABLE room_rls_context TO authenticated;
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.role', 'authenticated', true);
+SELECT set_config(
+        'request.jwt.claim.sub',
+        (
+            SELECT host_one_account_id::text
+            FROM room_rls_context
+        ),
+        true
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.game_sessions
+            WHERE id = (
+                    SELECT session_one_id
+                    FROM room_rls_context
+                )
+        ),
+        '1',
+        'host can read the game session row'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.participants
+            WHERE session_id = (
+                    SELECT session_one_id
+                    FROM room_rls_context
+                )
+        ),
+        '1',
+        'host can read the session participant rows'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.matches
+            WHERE id = (
+                    SELECT match_one_id
+                    FROM room_rls_context
+                )
+        ),
+        '1',
+        'host can read the session match rows'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.assignments
+            WHERE session_id = (
+                    SELECT session_one_id
+                    FROM room_rls_context
+                )
+        ),
+        '1',
+        'host can read the session assignment rows'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.gameplay_events
+            WHERE id = (
+                    SELECT event_one_id
+                    FROM room_rls_context
+                )
+        ),
+        '1',
+        'host can read the session gameplay events'
+    );
+SELECT set_config(
+        'request.jwt.claim.sub',
+        (
+            SELECT participant_one_account_id::text
+            FROM room_rls_context
+        ),
+        true
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.game_sessions
+            WHERE id = (
+                    SELECT session_one_id
+                    FROM room_rls_context
+                )
+        ),
+        '1',
+        'participant can read the game session row'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.participants
+            WHERE session_id = (
+                    SELECT session_one_id
+                    FROM room_rls_context
+                )
+        ),
+        '1',
+        'participant can read the session participant rows'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.matches
+            WHERE id = (
+                    SELECT match_one_id
+                    FROM room_rls_context
+                )
+        ),
+        '1',
+        'participant can read the session match rows'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.assignments
+            WHERE session_id = (
+                    SELECT session_one_id
+                    FROM room_rls_context
+                )
+        ),
+        '1',
+        'participant can read the session assignment rows'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.gameplay_events
+            WHERE id = (
+                    SELECT event_one_id
+                    FROM room_rls_context
+                )
+        ),
+        '1',
+        'participant can read the session gameplay events'
+    );
+SELECT set_config(
+        'request.jwt.claim.sub',
+        (
+            SELECT host_two_account_id::text
+            FROM room_rls_context
+        ),
+        true
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.game_sessions
+            WHERE id = (
+                    SELECT session_one_id
+                    FROM room_rls_context
+                )
+        ),
+        '0',
+        'unrelated host cannot read another session row'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.participants
+            WHERE session_id = (
+                    SELECT session_one_id
+                    FROM room_rls_context
+                )
+        ),
+        '0',
+        'unrelated host cannot read another session participants'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.matches
+            WHERE id = (
+                    SELECT match_one_id
+                    FROM room_rls_context
+                )
+        ),
+        '0',
+        'unrelated host cannot read another session matches'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.assignments
+            WHERE session_id = (
+                    SELECT session_one_id
+                    FROM room_rls_context
+                )
+        ),
+        '0',
+        'unrelated host cannot read another session assignments'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.gameplay_events
+            WHERE id = (
+                    SELECT event_one_id
+                    FROM room_rls_context
+                )
+        ),
+        '0',
+        'unrelated host cannot read another session gameplay events'
+    );
+RESET ROLE;
+SELECT *
+FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/060_privileged_write_paths.test.sql
+++ b/supabase/tests/database/060_privileged_write_paths.test.sql
@@ -1,0 +1,748 @@
+BEGIN;
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+SELECT plan(17);
+CREATE TEMP TABLE privileged_write_context AS WITH host_auth AS (
+    INSERT INTO auth.users (
+            id,
+            aud,
+            role,
+            email,
+            email_confirmed_at,
+            created_at,
+            updated_at,
+            raw_app_meta_data,
+            raw_user_meta_data,
+            is_sso_user,
+            is_anonymous
+        )
+    VALUES (
+            gen_random_uuid(),
+            'authenticated',
+            'authenticated',
+            'privileged-host@test.local',
+            now(),
+            now(),
+            now(),
+            '{"provider":"email","providers":["email"]}'::jsonb,
+            '{}'::jsonb,
+            FALSE,
+            FALSE
+        )
+    RETURNING id
+),
+participant_auth AS (
+    INSERT INTO auth.users (
+            id,
+            aud,
+            role,
+            email,
+            email_confirmed_at,
+            created_at,
+            updated_at,
+            raw_app_meta_data,
+            raw_user_meta_data,
+            is_sso_user,
+            is_anonymous
+        )
+    VALUES (
+            gen_random_uuid(),
+            'authenticated',
+            'authenticated',
+            'privileged-participant@test.local',
+            now(),
+            now(),
+            now(),
+            '{"provider":"email","providers":["email"]}'::jsonb,
+            '{}'::jsonb,
+            FALSE,
+            FALSE
+        )
+    RETURNING id
+),
+host_account AS (
+    INSERT INTO public.accounts (id, preferred_display_name)
+    SELECT id,
+        'Privileged Host'
+    FROM host_auth
+    RETURNING id
+),
+participant_account AS (
+    INSERT INTO public.accounts (id, preferred_display_name)
+    SELECT id,
+        'Privileged Participant'
+    FROM participant_auth
+    RETURNING id
+),
+session_row AS (
+    INSERT INTO public.game_sessions (host_account_id, join_code)
+    SELECT id,
+        'WRIT60'
+    FROM host_account
+    RETURNING id
+),
+participant_row AS (
+    INSERT INTO public.participants (
+            session_id,
+            account_id,
+            display_name,
+            membership_type
+        )
+    SELECT session_row.id,
+        participant_account.id,
+        'Privileged Participant',
+        'registered'
+    FROM session_row,
+        participant_account
+    RETURNING id
+),
+match_row AS (
+    INSERT INTO public.matches (
+            session_id,
+            source_provider,
+            source_match_id,
+            home_team_name,
+            away_team_name
+        )
+    SELECT session_row.id,
+        'espn',
+        'privileged-match-1',
+        'Privileged Home',
+        'Privileged Away'
+    FROM session_row
+    RETURNING id
+),
+assignment_row AS (
+    INSERT INTO public.assignments (session_id, participant_id, match_id)
+    SELECT session_row.id,
+        participant_row.id,
+        match_row.id
+    FROM session_row,
+        participant_row,
+        match_row
+    RETURNING session_id,
+        participant_id,
+        match_id
+),
+event_row AS (
+    INSERT INTO public.gameplay_events (
+            session_id,
+            sequence_number,
+            actor_participant_id,
+            event_type,
+            idempotency_key,
+            payload
+        )
+    SELECT session_row.id,
+        1,
+        participant_row.id,
+        'participant_joined',
+        'privileged-event-1',
+        '{}'::jsonb
+    FROM session_row,
+        participant_row
+    RETURNING id
+)
+SELECT (
+        SELECT id
+        FROM host_account
+    ) AS host_account_id,
+    (
+        SELECT id
+        FROM participant_account
+    ) AS participant_account_id,
+    (
+        SELECT id
+        FROM session_row
+    ) AS session_id,
+    (
+        SELECT id
+        FROM participant_row
+    ) AS participant_id,
+    (
+        SELECT id
+        FROM match_row
+    ) AS match_id,
+    (
+        SELECT id
+        FROM event_row
+    ) AS event_id;
+GRANT SELECT ON TABLE privileged_write_context TO authenticated,
+    service_role;
+CREATE TEMP TABLE privileged_write_results (
+    name text PRIMARY KEY,
+    passed boolean NOT NULL
+);
+GRANT SELECT,
+    INSERT ON TABLE privileged_write_results TO authenticated;
+CREATE TEMP TABLE privileged_write_artifacts (
+    service_session_id uuid,
+    service_participant_id uuid,
+    service_match_id uuid,
+    service_event_id uuid
+);
+INSERT INTO privileged_write_artifacts DEFAULT
+VALUES;
+GRANT SELECT,
+    UPDATE ON TABLE privileged_write_artifacts TO service_role;
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.role', 'authenticated', true);
+SELECT set_config(
+        'request.jwt.claim.sub',
+        (
+            SELECT host_account_id::text
+            FROM privileged_write_context
+        ),
+        true
+    );
+DO $$ BEGIN BEGIN
+INSERT INTO public.game_sessions (host_account_id, join_code)
+VALUES (
+        (
+            SELECT host_account_id
+            FROM privileged_write_context
+        ),
+        'WRIT61'
+    );
+INSERT INTO privileged_write_results
+VALUES (
+        'authenticated_insert_game_session_rejected',
+        FALSE
+    );
+EXCEPTION
+WHEN insufficient_privilege THEN
+INSERT INTO privileged_write_results
+VALUES (
+        'authenticated_insert_game_session_rejected',
+        TRUE
+    );
+END;
+END;
+$$;
+DO $$ BEGIN BEGIN
+UPDATE public.game_sessions
+SET state = 'in_progress'
+WHERE id = (
+        SELECT session_id
+        FROM privileged_write_context
+    );
+INSERT INTO privileged_write_results
+VALUES (
+        'authenticated_update_game_session_rejected',
+        FALSE
+    );
+EXCEPTION
+WHEN insufficient_privilege THEN
+INSERT INTO privileged_write_results
+VALUES (
+        'authenticated_update_game_session_rejected',
+        TRUE
+    );
+END;
+END;
+$$;
+DO $$ BEGIN BEGIN
+INSERT INTO public.participants (
+        session_id,
+        account_id,
+        display_name,
+        membership_type
+    )
+VALUES (
+        (
+            SELECT session_id
+            FROM privileged_write_context
+        ),
+        (
+            SELECT host_account_id
+            FROM privileged_write_context
+        ),
+        'Denied Host Participant',
+        'registered'
+    );
+INSERT INTO privileged_write_results
+VALUES (
+        'authenticated_insert_participant_rejected',
+        FALSE
+    );
+EXCEPTION
+WHEN insufficient_privilege THEN
+INSERT INTO privileged_write_results
+VALUES (
+        'authenticated_insert_participant_rejected',
+        TRUE
+    );
+END;
+END;
+$$;
+DO $$ BEGIN BEGIN
+UPDATE public.participants
+SET display_name = 'Denied Update'
+WHERE id = (
+        SELECT participant_id
+        FROM privileged_write_context
+    );
+INSERT INTO privileged_write_results
+VALUES (
+        'authenticated_update_participant_rejected',
+        FALSE
+    );
+EXCEPTION
+WHEN insufficient_privilege THEN
+INSERT INTO privileged_write_results
+VALUES (
+        'authenticated_update_participant_rejected',
+        TRUE
+    );
+END;
+END;
+$$;
+DO $$ BEGIN BEGIN
+INSERT INTO public.matches (
+        session_id,
+        source_provider,
+        source_match_id,
+        home_team_name,
+        away_team_name
+    )
+VALUES (
+        (
+            SELECT session_id
+            FROM privileged_write_context
+        ),
+        'espn',
+        'privileged-match-2',
+        'Denied Home',
+        'Denied Away'
+    );
+INSERT INTO privileged_write_results
+VALUES ('authenticated_insert_match_rejected', FALSE);
+EXCEPTION
+WHEN insufficient_privilege THEN
+INSERT INTO privileged_write_results
+VALUES ('authenticated_insert_match_rejected', TRUE);
+END;
+END;
+$$;
+DO $$ BEGIN BEGIN
+UPDATE public.matches
+SET home_score = 1
+WHERE id = (
+        SELECT match_id
+        FROM privileged_write_context
+    );
+INSERT INTO privileged_write_results
+VALUES ('authenticated_update_match_rejected', FALSE);
+EXCEPTION
+WHEN insufficient_privilege THEN
+INSERT INTO privileged_write_results
+VALUES ('authenticated_update_match_rejected', TRUE);
+END;
+END;
+$$;
+DO $$ BEGIN BEGIN
+INSERT INTO public.assignments (session_id, participant_id, match_id)
+VALUES (
+        (
+            SELECT session_id
+            FROM privileged_write_context
+        ),
+        (
+            SELECT participant_id
+            FROM privileged_write_context
+        ),
+        (
+            SELECT match_id
+            FROM privileged_write_context
+        )
+    );
+INSERT INTO privileged_write_results
+VALUES (
+        'authenticated_insert_assignment_rejected',
+        FALSE
+    );
+EXCEPTION
+WHEN insufficient_privilege THEN
+INSERT INTO privileged_write_results
+VALUES ('authenticated_insert_assignment_rejected', TRUE);
+END;
+END;
+$$;
+DO $$ BEGIN BEGIN
+DELETE FROM public.assignments
+WHERE session_id = (
+        SELECT session_id
+        FROM privileged_write_context
+    )
+    AND participant_id = (
+        SELECT participant_id
+        FROM privileged_write_context
+    )
+    AND match_id = (
+        SELECT match_id
+        FROM privileged_write_context
+    );
+INSERT INTO privileged_write_results
+VALUES (
+        'authenticated_delete_assignment_rejected',
+        FALSE
+    );
+EXCEPTION
+WHEN insufficient_privilege THEN
+INSERT INTO privileged_write_results
+VALUES ('authenticated_delete_assignment_rejected', TRUE);
+END;
+END;
+$$;
+DO $$ BEGIN BEGIN
+INSERT INTO public.gameplay_events (
+        session_id,
+        sequence_number,
+        actor_participant_id,
+        event_type,
+        idempotency_key,
+        payload
+    )
+VALUES (
+        (
+            SELECT session_id
+            FROM privileged_write_context
+        ),
+        2,
+        (
+            SELECT participant_id
+            FROM privileged_write_context
+        ),
+        'score_changed',
+        'privileged-event-2',
+        '{}'::jsonb
+    );
+INSERT INTO privileged_write_results
+VALUES (
+        'authenticated_insert_gameplay_event_rejected',
+        FALSE
+    );
+EXCEPTION
+WHEN insufficient_privilege THEN
+INSERT INTO privileged_write_results
+VALUES (
+        'authenticated_insert_gameplay_event_rejected',
+        TRUE
+    );
+END;
+END;
+$$;
+DO $$ BEGIN BEGIN
+DELETE FROM public.gameplay_events
+WHERE id = (
+        SELECT event_id
+        FROM privileged_write_context
+    );
+INSERT INTO privileged_write_results
+VALUES (
+        'authenticated_delete_gameplay_event_rejected',
+        FALSE
+    );
+EXCEPTION
+WHEN insufficient_privilege THEN
+INSERT INTO privileged_write_results
+VALUES (
+        'authenticated_delete_gameplay_event_rejected',
+        TRUE
+    );
+END;
+END;
+$$;
+RESET ROLE;
+SELECT ok(
+        (
+            SELECT passed
+            FROM privileged_write_results
+            WHERE name = 'authenticated_insert_game_session_rejected'
+        ),
+        'authenticated clients cannot insert game sessions directly'
+    );
+SELECT ok(
+        (
+            SELECT passed
+            FROM privileged_write_results
+            WHERE name = 'authenticated_update_game_session_rejected'
+        ),
+        'authenticated clients cannot update game sessions directly'
+    );
+SELECT ok(
+        (
+            SELECT passed
+            FROM privileged_write_results
+            WHERE name = 'authenticated_insert_participant_rejected'
+        ),
+        'authenticated clients cannot insert participants directly'
+    );
+SELECT ok(
+        (
+            SELECT passed
+            FROM privileged_write_results
+            WHERE name = 'authenticated_update_participant_rejected'
+        ),
+        'authenticated clients cannot update participants directly'
+    );
+SELECT ok(
+        (
+            SELECT passed
+            FROM privileged_write_results
+            WHERE name = 'authenticated_insert_match_rejected'
+        ),
+        'authenticated clients cannot insert matches directly'
+    );
+SELECT ok(
+        (
+            SELECT passed
+            FROM privileged_write_results
+            WHERE name = 'authenticated_update_match_rejected'
+        ),
+        'authenticated clients cannot update matches directly'
+    );
+SELECT ok(
+        (
+            SELECT passed
+            FROM privileged_write_results
+            WHERE name = 'authenticated_insert_assignment_rejected'
+        ),
+        'authenticated clients cannot insert assignments directly'
+    );
+SELECT ok(
+        (
+            SELECT passed
+            FROM privileged_write_results
+            WHERE name = 'authenticated_delete_assignment_rejected'
+        ),
+        'authenticated clients cannot delete assignments directly'
+    );
+SELECT ok(
+        (
+            SELECT passed
+            FROM privileged_write_results
+            WHERE name = 'authenticated_insert_gameplay_event_rejected'
+        ),
+        'authenticated clients cannot insert gameplay events directly'
+    );
+SELECT ok(
+        (
+            SELECT passed
+            FROM privileged_write_results
+            WHERE name = 'authenticated_delete_gameplay_event_rejected'
+        ),
+        'authenticated clients cannot delete gameplay events directly'
+    );
+SELECT ok(
+        EXISTS (
+            SELECT 1
+            FROM pg_roles
+            WHERE rolname = 'service_role'
+        ),
+        'service_role exists for privileged write smoke checks'
+    );
+SET LOCAL ROLE service_role;
+SELECT set_config('request.jwt.claim.role', 'service_role', true);
+WITH inserted_session AS (
+    INSERT INTO public.game_sessions (host_account_id, join_code)
+    VALUES (
+            (
+                SELECT host_account_id
+                FROM privileged_write_context
+            ),
+            'SRV601'
+        )
+    RETURNING id
+)
+UPDATE privileged_write_artifacts
+SET service_session_id = (
+        SELECT id
+        FROM inserted_session
+    );
+WITH inserted_participant AS (
+    INSERT INTO public.participants (
+            session_id,
+            account_id,
+            display_name,
+            membership_type
+        )
+    VALUES (
+            (
+                SELECT service_session_id
+                FROM privileged_write_artifacts
+            ),
+            (
+                SELECT participant_account_id
+                FROM privileged_write_context
+            ),
+            'Service Participant',
+            'registered'
+        )
+    RETURNING id
+)
+UPDATE privileged_write_artifacts
+SET service_participant_id = (
+        SELECT id
+        FROM inserted_participant
+    );
+WITH inserted_match AS (
+    INSERT INTO public.matches (
+            session_id,
+            source_provider,
+            source_match_id,
+            home_team_name,
+            away_team_name
+        )
+    VALUES (
+            (
+                SELECT service_session_id
+                FROM privileged_write_artifacts
+            ),
+            'espn',
+            'service-match-1',
+            'Service Home',
+            'Service Away'
+        )
+    RETURNING id
+)
+UPDATE privileged_write_artifacts
+SET service_match_id = (
+        SELECT id
+        FROM inserted_match
+    );
+INSERT INTO public.assignments (session_id, participant_id, match_id)
+VALUES (
+        (
+            SELECT service_session_id
+            FROM privileged_write_artifacts
+        ),
+        (
+            SELECT service_participant_id
+            FROM privileged_write_artifacts
+        ),
+        (
+            SELECT service_match_id
+            FROM privileged_write_artifacts
+        )
+    );
+WITH inserted_event AS (
+    INSERT INTO public.gameplay_events (
+            session_id,
+            sequence_number,
+            actor_participant_id,
+            event_type,
+            idempotency_key,
+            payload
+        )
+    VALUES (
+            (
+                SELECT service_session_id
+                FROM privileged_write_artifacts
+            ),
+            1,
+            (
+                SELECT service_participant_id
+                FROM privileged_write_artifacts
+            ),
+            'participant_joined',
+            'service-event-1',
+            '{}'::jsonb
+        )
+    RETURNING id
+)
+UPDATE privileged_write_artifacts
+SET service_event_id = (
+        SELECT id
+        FROM inserted_event
+    );
+UPDATE public.matches
+SET home_score = 2
+WHERE id = (
+        SELECT service_match_id
+        FROM privileged_write_artifacts
+    );
+RESET ROLE;
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.game_sessions
+            WHERE id = (
+                    SELECT service_session_id
+                    FROM privileged_write_artifacts
+                )
+        ),
+        '1',
+        'service_role can insert game sessions'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.participants
+            WHERE id = (
+                    SELECT service_participant_id
+                    FROM privileged_write_artifacts
+                )
+        ),
+        '1',
+        'service_role can insert participants'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.matches
+            WHERE id = (
+                    SELECT service_match_id
+                    FROM privileged_write_artifacts
+                )
+        ),
+        '1',
+        'service_role can insert matches'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.assignments
+            WHERE session_id = (
+                    SELECT service_session_id
+                    FROM privileged_write_artifacts
+                )
+                AND participant_id = (
+                    SELECT service_participant_id
+                    FROM privileged_write_artifacts
+                )
+                AND match_id = (
+                    SELECT service_match_id
+                    FROM privileged_write_artifacts
+                )
+        ),
+        '1',
+        'service_role can insert assignments'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.gameplay_events
+            WHERE id = (
+                    SELECT service_event_id
+                    FROM privileged_write_artifacts
+                )
+        ),
+        '1',
+        'service_role can insert gameplay events'
+    );
+SELECT is(
+        (
+            SELECT home_score::text
+            FROM public.matches
+            WHERE id = (
+                    SELECT service_match_id
+                    FROM privileged_write_artifacts
+                )
+        ),
+        '2',
+        'service_role can update room state through the approved path'
+    );
+SELECT *
+FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Implements US2.2 with new social tables, explicit grants, row-level security policies for profiles/settings/friendships, room-read policies, and pgTAP coverage for the access matrix.

Validation:
- npx --yes supabase db reset
- npx --yes supabase test db
- npm run lint (warnings only)