### PR TITLE
Add comprehensive tests for history read models and performance metrics

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,8 @@ Auto-generated from all feature plans. Last updated: 2026-05-09
 - New top-level `supabase/` workspace for SQL migrations and database tests; Supabase Postgres becomes the canonical multiplayer store while the existing locally persisted session snapshot remains the temporary local cache until client integration ships (128-us21-create-the-core-supabase-schema-for-accounts-sessions-participants-matches-assignments-and-events)
 - TypeScript 5.3.3 in an Expo SDK 52 / React Native 0.76.9 workspace, plus SQL migrations executed through Supabase CLI against local Supabase Postgres + Supabase CLI, Supabase Auth/Postgres local stack, pgTAP database tests, existing Expo Router 4 workspace, existing Supabase `public.accounts` anchor from US2.1 (151-add-data-rls)
 - New `supabase/` workspace in the repo, with additional `public` schema tables for profiles, settings, and friendships, and RLS enabled on those tables plus the existing room tables (151-add-data-rls)
+- TypeScript 5.3.3 in an Expo SDK 52 / React Native 0.76.9 workspace, plus SQL migrations and pgTAP tests executed against local Supabase Postgres + Supabase CLI, Supabase Auth/Postgres local stack, pgTAP database tests, existing Expo Router 4 workspace, Supabase `rpc()` support for SQL functions (126-us23-create-read-models-for-history-comparisons-and-leaderboards)
+- Existing `supabase/` workspace with new read-model views/functions and supporting tests; no new business tables are introduced in this feature (126-us23-create-read-models-for-history-comparisons-and-leaderboards)
 
 - TypeScript 5.3.3 in an Expo SDK 52 / React Native 0.76.9 workspace + Expo Router 4, React 18.3.1, Zustand 5, AsyncStorage, `expo-av`, `react-native-date-picker`, `react-native-ui-datepicker`, `lottie-react-native`, `react-native-gesture-handler`, `react-native-reanimated`, Jest-Expo 52 (111-add-platform-abstractions)
 - Existing Zustand + AsyncStorage persistence remains unchanged; no new storage for this feature (111-add-platform-abstractions)
@@ -41,9 +43,9 @@ npm test; npm run lint
 Markdown documentation artifact inside a TypeScript 5.3.3 / Expo SDK 52 workspace: Follow standard conventions
 
 ## Recent Changes
+- 126-us23-create-read-models-for-history-comparisons-and-leaderboards: Added TypeScript 5.3.3 in an Expo SDK 52 / React Native 0.76.9 workspace, plus SQL migrations and pgTAP tests executed against local Supabase Postgres + Supabase CLI, Supabase Auth/Postgres local stack, pgTAP database tests, existing Expo Router 4 workspace, Supabase `rpc()` support for SQL functions
 - 151-add-data-rls: Added TypeScript 5.3.3 in an Expo SDK 52 / React Native 0.76.9 workspace, plus SQL migrations executed through Supabase CLI against local Supabase Postgres + Supabase CLI, Supabase Auth/Postgres local stack, pgTAP database tests, existing Expo Router 4 workspace, existing Supabase `public.accounts` anchor from US2.1
 - 128-us21-create-the-core-supabase-schema-for-accounts-sessions-participants-matches-assignments-and-events: Added TypeScript 5.3.3 Expo workspace plus SQL migrations executed via Supabase CLI against local Supabase Postgres + Supabase CLI, Supabase Auth/Postgres local stack, pgTAP database tests, `basejump-supabase_test_helpers` for authenticated DB test contexts, existing Expo SDK 52 / React Native 0.76.9 workspace
-- multiplayer: Added TypeScript 5.3.3 + Expo SDK 52, React Native 0.76.9, React 18.3.1, Expo Router 4, `playwright-bdd` 8.5.0, `@playwright/test` 1.59.1, `react-native-safe-area-context`, `react-native-toast-message`, Zustand 5
 
 
 

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/008-add-data-rls"
+  "feature_directory": "specs/009-history-read-models"
 }

--- a/specs/009-history-read-models/checklists/requirements.md
+++ b/specs/009-history-read-models/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: History, Comparison, and Leaderboard Read Models
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/009-history-read-models/contracts/read-model-contracts.md
+++ b/specs/009-history-read-models/contracts/read-model-contracts.md
@@ -1,0 +1,192 @@
+# Read Model Contracts: History, Comparison, and Leaderboard
+
+## Overview
+
+This contract defines the public database surfaces that replace the current client-side aggregation in the history screen. The implementation should use `security_invoker` views for unparameterized reads and stable SQL functions for parameterized comparisons.
+
+All contracts are read-only for authenticated clients. Explicit `GRANT` statements must be present for the exposed surfaces.
+
+## Contract 1: Completed Session History
+
+### Surface
+
+- `public.completed_session_summaries` view
+
+### Access
+
+- `SELECT` for `authenticated`
+
+### Purpose
+
+Return one row per completed session with enough nested data to render the Games tab and details modal without client-side reconstruction.
+
+### Required Fields
+
+| Field                   | Type          | Notes                    |
+| ----------------------- | ------------- | ------------------------ | ------------ |
+| `session_id`            | `uuid`        | Completed session id     |
+| `host_account_id`       | `uuid`        | Session host             |
+| `completed_at`          | `timestamptz` | Completion timestamp     |
+| `started_at`            | `timestamptz` | Session start time       |
+| `common_match_id`       | `uuid         | null`                    | Common match |
+| `session_total_players` | `integer`     | Participant count        |
+| `session_total_matches` | `integer`     | Match count              |
+| `session_total_goals`   | `integer`     | Aggregated goals         |
+| `session_total_drinks`  | `numeric`     | Aggregated drinks        |
+| `matches_per_player`    | `numeric`     | Session metric           |
+| `players`               | `jsonb`       | Ordered player snapshots |
+| `matches`               | `jsonb`       | Ordered match snapshots  |
+| `player_assignments`    | `jsonb`       | Participant-to-match map |
+
+### Notes
+
+- The view should only include completed sessions.
+- Guests remain visible only within the session snapshot.
+
+## Contract 2: History Overview Totals
+
+### Surface
+
+- `public.history_overview_totals` view
+
+### Access
+
+- `SELECT` for `authenticated`
+
+### Purpose
+
+Return the overall totals used by the Stats tab without client-side summation.
+
+### Required Fields
+
+| Field                              | Type      | Notes                           |
+| ---------------------------------- | --------- | ------------------------------- |
+| `total_sessions`                   | `integer` | Completed session count         |
+| `total_participations`             | `integer` | Participant row count           |
+| `total_matches`                    | `integer` | Match count                     |
+| `total_goals`                      | `integer` | Total goals                     |
+| `total_drinks`                     | `numeric` | Total drinks                    |
+| `average_drinks_per_participation` | `numeric` | Mean drinks per participant row |
+
+### Notes
+
+- The view should be deterministic for the same underlying dataset.
+
+## Contract 3: Lifetime Player Stats
+
+### Surface
+
+- `public.lifetime_player_stats` view
+
+### Access
+
+- `SELECT` for `authenticated`
+
+### Purpose
+
+Return durable player totals keyed by account identity for the Players tab and for leaderboard ranking.
+
+### Required Fields
+
+| Field              | Type      | Notes                     |
+| ------------------ | --------- | ------------------------- |
+| `account_id`       | `uuid`    | Registered identity key   |
+| `display_name`     | `text`    | Display name              |
+| `games_played`     | `integer` | Completed sessions played |
+| `total_drinks`     | `numeric` | Sum of drinks             |
+| `average_per_game` | `numeric` | Average drinks per game   |
+
+### Notes
+
+- Guest participants must not appear in this view.
+- This is the source view for the leaderboard.
+
+## Contract 4: Leaderboard
+
+### Surface
+
+- `public.leaderboard_entries` view
+
+### Access
+
+- `SELECT` for `authenticated`
+
+### Purpose
+
+Return ranked registered accounts ordered by total drinks consumed in completed sessions.
+
+### Required Fields
+
+| Field              | Type      | Notes                   |
+| ------------------ | --------- | ----------------------- |
+| `rank`             | `integer` | Deterministic rank      |
+| `account_id`       | `uuid`    | Registered identity key |
+| `display_name`     | `text`    | Display name            |
+| `total_drinks`     | `numeric` | Primary rank metric     |
+| `games_played`     | `integer` | Supporting stat         |
+| `average_per_game` | `numeric` | Tie-break metric        |
+
+### Ordering Rules
+
+1. `total_drinks` descending
+2. `average_per_game` descending
+3. `account_id` ascending
+
+### Notes
+
+- Guests are excluded from permanent rankings.
+- The rank column should be stable for the same dataset.
+
+## Contract 5: Registered User Comparison
+
+### Surface
+
+- `public.compare_registered_players(left_account_id uuid, right_account_id uuid)`
+
+### Access
+
+- `EXECUTE` for `authenticated`
+
+### Purpose
+
+Return the fully aggregated head-to-head metrics for two registered accounts across all completed sessions.
+
+### Required Fields
+
+All fields from `ComparisonResult` in [data-model.md](../data-model.md).
+
+### Notes
+
+- The function must return zero shared-session metrics and an empty timeline when the two registered users have no shared completed sessions.
+- The function must be stable and deterministic.
+
+## Contract 6: Session-Scoped Participant Comparison
+
+### Surface
+
+- `public.compare_session_participants(session_id uuid, left_participant_id uuid, right_participant_id uuid)`
+
+### Access
+
+- `EXECUTE` for `authenticated`
+
+### Purpose
+
+Return the comparison metrics for any two participants that both belong to the same completed session snapshot, including guest participants.
+
+### Required Fields
+
+All fields from `ComparisonResult` in [data-model.md](../data-model.md).
+
+### Notes
+
+- The function must reject requests where both participant ids are not members of the supplied completed session.
+- Guest comparisons must remain session-scoped and must not aggregate across unrelated sessions.
+
+## Client Mapping
+
+- History screen `Games` tab -> `completed_session_summaries`
+- History screen `Stats` tab -> `history_overview_totals`
+- History screen `Players` tab -> `lifetime_player_stats`
+- Player comparison modal -> `compare_registered_players` or `compare_session_participants` depending on identity scope
+- Leaderboard screen -> `leaderboard_entries`

--- a/specs/009-history-read-models/data-model.md
+++ b/specs/009-history-read-models/data-model.md
@@ -1,0 +1,141 @@
+# Data Model: History, Comparison, and Leaderboard Read Models
+
+## Overview
+
+This feature does not introduce new business tables. It adds derived read-model contracts over the existing multiplayer schema so the client can load completed-session history, lifetime player stats, comparison metrics, and leaderboards without re-aggregating local state.
+
+The contracts are read-only and are built from the existing completed-session graph:
+
+- `game_sessions` provides the completed-session boundary and timestamps.
+- `participants` provides session-scoped player identity and per-session drink totals.
+- `matches` provides the fixture and score data needed by history and comparison views.
+- `assignments` provides the session-scoped player-to-match mapping.
+
+## Derived Entities
+
+### CompletedSessionSummary
+
+Represents one completed session in the history list and details view.
+
+| Field                   | Type          | Notes                                              |
+| ----------------------- | ------------- | -------------------------------------------------- | -------------------- |
+| `session_id`            | `uuid`        | Session primary key                                |
+| `host_account_id`       | `uuid`        | Host identity                                      |
+| `completed_at`          | `timestamptz` | Completion timestamp                               |
+| `started_at`            | `timestamptz` | Session start time                                 |
+| `common_match_id`       | `uuid         | null`                                              | Session common match |
+| `session_total_players` | `integer`     | Participant count                                  |
+| `session_total_matches` | `integer`     | Match count                                        |
+| `session_total_goals`   | `integer`     | Home + away goals across matches                   |
+| `session_total_drinks`  | `numeric`     | Total drinks across participants                   |
+| `matches_per_player`    | `numeric`     | Derived session metric                             |
+| `players`               | `jsonb`       | Ordered session participants, including guest rows |
+| `matches`               | `jsonb`       | Ordered session matches with score data            |
+| `player_assignments`    | `jsonb`       | Participant-to-match mapping                       |
+
+**Relationships**
+
+- One summary row per completed session.
+- Guest participants remain represented only inside their session summary.
+
+### HistoryOverviewTotals
+
+Represents the aggregated totals used by the Stats tab.
+
+| Field                              | Type      | Notes                                            |
+| ---------------------------------- | --------- | ------------------------------------------------ |
+| `total_sessions`                   | `integer` | Completed-session count                          |
+| `total_participations`             | `integer` | Total participant rows across completed sessions |
+| `total_matches`                    | `integer` | Total match rows across completed sessions       |
+| `total_goals`                      | `integer` | Total goals across all completed sessions        |
+| `total_drinks`                     | `numeric` | Total drinks across all completed sessions       |
+| `average_drinks_per_participation` | `numeric` | Total drinks divided by participant rows         |
+
+**Relationships**
+
+- One row per query scope.
+- Derived from completed-session summaries or the base session tables.
+
+### LifetimePlayerStat
+
+Represents one durable player aggregate keyed by account identity.
+
+| Field              | Type      | Notes                                     |
+| ------------------ | --------- | ----------------------------------------- |
+| `account_id`       | `uuid`    | Registered identity key                   |
+| `display_name`     | `text`    | Current durable display name              |
+| `games_played`     | `integer` | Completed sessions containing the account |
+| `total_drinks`     | `numeric` | Sum of completed-session drink totals     |
+| `average_per_game` | `numeric` | `total_drinks / games_played`             |
+
+**Relationships**
+
+- One row per registered account with completed-session participation.
+- Guest participants are excluded because they do not have durable account identity.
+
+### ComparisonResult
+
+Represents a fully aggregated head-to-head result for two selected participants.
+
+| Field                         | Type      | Notes                                         |
+| ----------------------------- | --------- | --------------------------------------------- |
+| `player1_id`                  | `uuid`    | Registered account or session participant id  |
+| `player2_id`                  | `uuid`    | Registered account or session participant id  |
+| `player1_name`                | `text`    | Display name                                  |
+| `player2_name`                | `text`    | Display name                                  |
+| `player1_games_played`        | `integer` | Total completed sessions for player 1         |
+| `player2_games_played`        | `integer` | Total completed sessions for player 2         |
+| `player1_total_drinks`        | `numeric` | Total drinks across the compared scope        |
+| `player2_total_drinks`        | `numeric` | Total drinks across the compared scope        |
+| `player1_average_per_game`    | `numeric` | Average drinks per game                       |
+| `player2_average_per_game`    | `numeric` | Average drinks per game                       |
+| `games_played_together`       | `integer` | Shared-session count for the comparison scope |
+| `player1_wins_count`          | `integer` | Comparison-scope wins                         |
+| `player2_wins_count`          | `integer` | Comparison-scope wins                         |
+| `tied_games_count`            | `integer` | Comparison-scope ties                         |
+| `player1_max_in_a_game`       | `numeric` | Highest single-session total                  |
+| `player2_max_in_a_game`       | `numeric` | Highest single-session total                  |
+| `player1_common_match_count`  | `integer` | Common-match appearances                      |
+| `player2_common_match_count`  | `integer` | Common-match appearances                      |
+| `player1_efficiency`          | `numeric` | Drinks per match                              |
+| `player2_efficiency`          | `numeric` | Drinks per match                              |
+| `player1_top_drinker_count`   | `integer` | Top-drinker frequency                         |
+| `player2_top_drinker_count`   | `integer` | Top-drinker frequency                         |
+| `player1_avg_with_player2`    | `numeric` | Influence metric                              |
+| `player1_avg_without_player2` | `numeric` | Influence metric                              |
+| `player2_avg_with_player1`    | `numeric` | Influence metric                              |
+| `player2_avg_without_player1` | `numeric` | Influence metric                              |
+| `timeline_data`               | `jsonb`   | Ordered timeline points                       |
+
+**Relationships**
+
+- Registered-user comparisons aggregate across all completed sessions.
+- Guest comparisons are only valid inside a single completed session snapshot.
+- If two registered users have no shared completed sessions, the shared-session metrics are zero and `timeline_data` is empty.
+
+### LeaderboardEntry
+
+Represents one ranked row in the leaderboard view.
+
+| Field              | Type      | Notes                      |
+| ------------------ | --------- | -------------------------- |
+| `rank`             | `integer` | Deterministic order number |
+| `account_id`       | `uuid`    | Registered identity key    |
+| `display_name`     | `text`    | Display name               |
+| `total_drinks`     | `numeric` | Primary ranking metric     |
+| `games_played`     | `integer` | Supporting stat            |
+| `average_per_game` | `numeric` | Secondary tie-break metric |
+
+**Relationships**
+
+- One row per ranked registered account.
+- Guests are not ranked.
+
+## Validation Rules
+
+- Completed-session read models only include sessions with a completed state.
+- History summaries preserve guest participants only as session-scoped rows.
+- Lifetime stats and leaderboards are keyed by registered account identity.
+- Leaderboards sort by `total_drinks` descending, `average_per_game` descending, then `account_id` ascending.
+- Comparison functions return zeroed shared metrics rather than errors for registered users with no overlap.
+- Guest comparisons are only valid when both inputs belong to the same completed session snapshot.

--- a/specs/009-history-read-models/plan.md
+++ b/specs/009-history-read-models/plan.md
@@ -1,0 +1,93 @@
+# Implementation Plan: History, Comparison, and Leaderboard Read Models
+
+**Branch**: `126-us23-create-read-models-for-history-comparisons-and-leaderboards` | **Date**: 2026-05-09 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from [spec.md](spec.md)
+
+## Summary
+
+Deliver a read-model layer in Supabase Postgres for completed session history, lifetime player stats, head-to-head comparisons, and ranked leaderboards so the client can stop recomputing those aggregates locally. The design uses `security_invoker` views for the unparameterized read surfaces and stable SQL RPC functions for comparison queries, with pgTAP tests and query benchmarks proving that the contracts are deterministic, guest-scoped where required, and index-backed.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.3.3 in an Expo SDK 52 / React Native 0.76.9 workspace, plus SQL migrations and pgTAP tests executed against local Supabase Postgres  
+**Primary Dependencies**: Supabase CLI, Supabase Auth/Postgres local stack, pgTAP database tests, existing Expo Router 4 workspace, Supabase `rpc()` support for SQL functions  
+**Storage**: Existing `supabase/` workspace with new read-model views/functions and supporting tests; no new business tables are introduced in this feature  
+**Testing**: pgTAP schema, result-shape, and performance validation for completed-session summaries, overview totals, lifetime stats, comparisons, and leaderboards; no new end-to-end UI coverage in this slice  
+**Applicable Skills**: `supabase`, `supabase-postgres-best-practices`, `database-design-expert`, `database-testing`  
+**Target Platform**: Local Supabase/Postgres backing the existing cross-platform Expo app on native and web  
+**Project Type**: Cross-platform Expo application with a first-party Supabase database workspace  
+**Performance Goals**: Keep read-model queries deterministic and index-backed; avoid client-side aggregation for the affected history, player, comparison, and leaderboard views; validate query plans on representative completed-session fixtures  
+**Constraints**: Expose read models with explicit grants; use `security_invoker` for views so underlying RLS remains authoritative; keep guest participants session-scoped; avoid materialized views unless benchmarking shows a clear need; do not introduce a custom backend just for these aggregates  
+**Scale/Scope**: One Supabase workspace, four read surfaces in the data layer (history overview, lifetime stats, comparisons, leaderboard), a small set of SQL migrations, pgTAP coverage, and documentation for the client contract
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+- PASS: Cross-platform behavior is unchanged in the UI layer; the feature defines one shared data contract for native and web clients.
+- PASS: Supabase Postgres remains the canonical source of truth for the new read models, and the write path is not expanded by this story.
+- PASS: The design is read-model oriented, with no new mutable history tables; migration and backfill impact is limited to derived queries and supporting indexes.
+- PASS: The work is sliced into independently deliverable user stories with Gherkin acceptance criteria and explicit edge cases.
+- PASS: The test plan includes unit-equivalent database coverage for every new read-model contract and query-performance validation for the sensitive paths.
+- PASS: Applicable repository and domain skills were identified before planning began and directly informed the security and performance choices.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-history-read-models/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── read-model-contracts.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+supabase/
+├── config.toml
+├── migrations/
+└── tests/
+    └── database/
+app/
+├── history.tsx
+└── style/
+components/
+├── history/
+├── ui/
+└── AppIcon.tsx
+store/
+README.md
+package.json
+```
+
+**Structure Decision**: This feature stays database-first inside the existing Expo monorepo. Implementation work lands in `supabase/migrations/`, `supabase/tests/database/`, and the documentation under `specs/009-history-read-models/`; the current Expo screens remain unchanged until a later client-integration story consumes the new read models.
+
+## Phase 0 Output
+
+- `research.md` resolves the choice of `security_invoker` views for the unparameterized surfaces, SQL RPC functions for comparison queries, and the initial no-materialized-view approach.
+- The read-model contract is scoped against the current history screen shapes so the derived data can replace the client’s local history, stats, and comparison aggregation.
+
+## Phase 1 Output
+
+- `data-model.md` defines the derived read-model entities, their fields, and how they map to completed sessions, participants, and leaderboard rows.
+- `contracts/read-model-contracts.md` documents the public view/function names, response shapes, and guest-vs-registered comparison rules.
+- `quickstart.md` documents the Supabase CLI workflow, database-test execution, and benchmark validation steps.
+- The copilot agent context is refreshed after the design artifacts are written.
+
+## Post-Design Constitution Check
+
+- PASS: No UI divergence is introduced; the same contract can be consumed by native and web clients later.
+- PASS: The read models remain database-derived and do not redefine the server-authoritative mutation model.
+- PASS: There is no new mutable history store; the feature only adds read surfaces and supporting validation.
+- PASS: The test plan covers shape, access, and performance behavior in the database layer where these contracts live.
+- PASS: All applicable skills remained explicit throughout planning and design.
+
+## Complexity Tracking
+
+No constitution violations or exceptional complexity adjustments are required for this feature.

--- a/specs/009-history-read-models/quickstart.md
+++ b/specs/009-history-read-models/quickstart.md
@@ -1,0 +1,110 @@
+# Quickstart: History, Comparison, and Leaderboard Read Models
+
+## Purpose
+
+This quickstart covers how to implement and verify the read-model layer for issue #126 without changing the current Expo screens in the same slice.
+
+## Prerequisites
+
+- Docker Desktop or another supported local container runtime
+- Node.js and npm already used by this repo
+- Supabase CLI available through `npx supabase`
+- Repository root at `C:\src\dong`
+
+## Initial Setup
+
+1. Start the local Supabase stack.
+
+```powershell
+npx supabase start
+```
+
+2. Confirm the local database is healthy.
+
+```powershell
+npx supabase status
+```
+
+## Implementation Order
+
+1. Create a migration scaffold for the read-model changes.
+
+```powershell
+npx supabase migration new add_history_read_models
+```
+
+2. Implement the read surfaces in this order:
+
+- `completed_session_summaries` security-invoker view
+- `history_overview_totals` security-invoker view
+- `lifetime_player_stats` security-invoker view
+- `leaderboard_entries` security-invoker view
+- `compare_registered_players` stable SQL function
+- `compare_session_participants` stable SQL function
+- explicit grants for `authenticated` and `service_role`
+- supporting indexes if benchmarked queries need them
+
+3. Add pgTAP tests under `supabase/tests/database/`.
+
+Recommended initial files:
+
+- `070_history_read_models_schema.test.sql`
+- `080_history_read_models_results.test.sql`
+- `090_history_read_models_contract.test.sql`
+- `100_history_read_models_performance.test.sql`
+
+## Authenticated User Testing
+
+Use pgTAP fixtures inside rolled-back transactions to seed `auth.users` rows and matching `public.accounts` rows. For guest scenarios, seed the session-scoped `participants` rows directly and keep the comparison tests focused on the relevant completed session snapshot.
+
+Avoid browser or Expo login flows for this feature. The core validation target is the database contract matrix.
+
+## Verification Workflow
+
+1. Reset the local database so migrations apply from scratch.
+
+```powershell
+npx supabase db reset
+```
+
+2. Run the database tests.
+
+```powershell
+npx supabase test db
+```
+
+The test suite covers history summaries, lifetime stats, comparisons, leaderboards, and a performance smoke file under `supabase/tests/database/`.
+
+3. Benchmark the representative read-model queries.
+
+Use either a dedicated performance pgTAP file or `EXPLAIN (ANALYZE, BUFFERS)` against the fixture data to confirm the query plan stays index-backed and deterministic.
+
+4. If repository metadata or developer guidance changed, run lint as the final repo-level check.
+
+```powershell
+npm run lint
+```
+
+## Smoke Checklist
+
+- Completed-session history only returns completed sessions.
+- History overview totals match the underlying completed-session dataset.
+- Lifetime stats exclude guest participants.
+- Leaderboards are ordered by total drinks, then average drinks per game, then account ID.
+- Registered-user comparisons return zero shared-session metrics and an empty timeline when there is no overlap.
+- Guest comparisons are only valid inside one completed session snapshot.
+
+## Out of Scope For This Story
+
+- Expo or browser login UI tests
+- Materialized views unless performance benchmarks show they are required
+- One-time local-to-cloud import
+- Client integration with the new read models
+
+## Shutdown
+
+When you are done with local database work:
+
+```powershell
+npx supabase stop
+```

--- a/specs/009-history-read-models/research.md
+++ b/specs/009-history-read-models/research.md
@@ -1,0 +1,67 @@
+# Research: History, Comparison, and Leaderboard Read Models
+
+## Decision 1: Use `security_invoker` views for the non-parameterized read models
+
+**Decision**: Implement the completed-session history overview, history totals, lifetime stats, and leaderboard as `security_invoker` views in the exposed schema.
+
+**Rationale**: Supabase views bypass RLS by default unless they are created with `security_invoker = true`. The feature needs read surfaces that obey the underlying access rules without introducing a privileged helper layer, and conventional views keep the contract simple for the client.
+
+**Alternatives considered**:
+
+- Materialized views: rejected for v1 because the feature needs fresh results and the issue explicitly asks for benchmark validation before adding complexity.
+- Private-schema helpers only: rejected because the client still needs a stable public read contract and the data should remain reachable through explicit grants.
+
+## Decision 2: Use stable SQL functions for the comparison contracts
+
+**Decision**: Implement comparison as stable SQL RPC functions, one for registered-user comparisons across completed sessions and one for session-scoped participant comparisons that can include guests when both inputs belong to the same completed session snapshot.
+
+**Rationale**: Supabase database functions are callable through `rpc()`, can return table-shaped results, and are the right fit for parameterized read contracts. A function is also the cleanest way to return the fully aggregated comparison result, including timeline data, without forcing the client to recompute the metrics.
+
+**Alternatives considered**:
+
+- Client-side composition from multiple views: rejected because the feature goal is to stop local aggregation.
+- A single overloaded function: rejected because the contracts are easier to reason about if the registered-user and session-scoped guest cases are explicit.
+
+## Decision 3: Base all derived reads on completed sessions and participant rows
+
+**Decision**: Derive session summaries, lifetime totals, comparisons, and leaderboards from `game_sessions`, `participants`, `matches`, and `assignments`, filtered to completed sessions. Use `participants.current_drink_total` as the per-session drink total and `accounts.id` as the durable key for registered users.
+
+**Rationale**: The current schema already stores the final session-level totals and relationships needed by the client. Building read models from those tables avoids replaying gameplay events just to answer dashboard queries and keeps the contracts index-friendly.
+
+**Alternatives considered**:
+
+- Deriving from `gameplay_events`: rejected because it adds replay complexity that is not needed for the read-model slice.
+- Introducing new summary tables: rejected because the issue asks for read models/views rather than a second mutable persistence layer.
+
+## Decision 4: Keep leaderboards deterministic with a documented tie-break
+
+**Decision**: Rank leaderboards by total drinks consumed in completed sessions, then by average drinks per game, then by `account_id` ascending.
+
+**Rationale**: The clarified spec chose this order and it is deterministic, stable, and cheap to compute from the lifetime stats view. The extra tie-break on account ID prevents flicker for equal values.
+
+**Alternatives considered**:
+
+- Total games played as the primary rank: rejected because it would not match the agreed v1 behavior.
+- Display name as the tie-break: rejected because names are not stable identity keys.
+
+## Decision 5: Preserve guest session scope in comparisons
+
+**Decision**: Allow guest participants in comparisons only when both inputs belong to the same completed session snapshot. Registered-user comparisons may span any completed sessions; if two registered users have no shared completed sessions, the comparison returns zero shared-session metrics and an empty timeline.
+
+**Rationale**: Guests do not have durable identity in v1, so they must not be promoted into cross-session ranking. Registered users, however, can be compared across the full completed-session history because they do have durable account identity.
+
+**Alternatives considered**:
+
+- Reject guest comparisons entirely: rejected because the current client comparison flow still needs to compare session participants inside a history snapshot.
+- Force registered-user comparisons to share a session: rejected because it would make the current comparison contract less useful than the existing client logic.
+
+## Decision 6: Validate with pgTAP and benchmarked query plans
+
+**Decision**: Use pgTAP tests for schema shape, result shapes, and guest/registered behavior, plus representative query benchmarks for the new read-model surfaces.
+
+**Rationale**: This feature is database-first and performance-sensitive. pgTAP gives a repeatable way to prove the SQL contract, while benchmark checks make sure the views and functions remain practical as the dataset grows.
+
+**Alternatives considered**:
+
+- UI end-to-end coverage only: rejected because the contract is in the database layer and no new UI ships in this slice.
+- Manual verification only: rejected because the issue explicitly requires validation and the repo already uses automated database tests.

--- a/specs/009-history-read-models/spec.md
+++ b/specs/009-history-read-models/spec.md
@@ -1,0 +1,150 @@
+# Feature Specification: History, Comparison, and Leaderboard Read Models
+
+**Feature Branch**: `126-us23-create-read-models-for-history-comparisons-and-leaderboards`  
+**Created**: 2026-05-09  
+**Status**: Draft  
+**Input**: User description: "Plan implementation for issue #126 '[US2.3] Create read models for history, comparisons, and leaderboards' using epic #115 and the existing multiplayer schema context."
+
+## Clarifications
+
+### Session 2026-05-09
+
+- Q: What leaderboard metric should v1 use? → A: Rank registered users by total drinks consumed in completed sessions.
+- Q: How should leaderboard ties be broken? → A: Break ties by higher average drinks per game, then registered account ID ascending.
+- Q: Should comparison reads support guests or only registered users? → A: Support both registered users and guest session participants, with guest results scoped to the session snapshot.
+- Q: When a comparison includes a guest, what scope should it use? → A: Guest-vs-registered comparisons are only allowed when both participants appear in the same completed session snapshot.
+- Q: Should registered-user comparisons require shared sessions? → A: Registered-user comparisons may cover any two registered users across completed sessions; if they have no shared sessions, shared-session metrics are zero and the timeline is empty.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Completed History Loads Without Local Recalculation (Priority: P1)
+
+As a player opening History, I can load completed session summaries, so the Games tab and details view show consistent results without recomputing session totals on the client.
+
+**Why this priority**: History summaries are the primary consumer of the derived data and are needed before the client can stop recalculating session aggregates locally.
+
+**Independent Test**: Load a representative set of completed sessions and confirm the returned summary data is sufficient to render the Games tab and details view without any extra aggregation step in the client.
+
+**Acceptance Scenarios (Gherkin style)**:
+
+1. **Given** completed multiplayer sessions exist, **When** the history summary data is requested, **Then** the response includes the completed session identity, participants, matches, common match selection, completion timing, and summary totals needed by the history screen.
+2. **Given** a completed session with guest and registered participants, **When** the session summary is requested, **Then** the response includes the guest participants only for that session and preserves the registered participant identities for durable references.
+3. **Given** the same completed session data is requested repeatedly, **When** the client reloads the summary, **Then** the returned shape and ordering remain stable for the same underlying dataset.
+
+---
+
+### User Story 2 - Lifetime Stats Stay Keyed To Registered Identity (Priority: P1)
+
+As a signed-in player, I can load my lifetime totals across completed sessions, so the Players and Stats tabs show one durable record per registered account.
+
+**Why this priority**: Lifetime totals are the second major consumer of the derived data and are the basis for the visible player stats experience.
+
+**Independent Test**: Query multiple completed sessions and confirm registered users aggregate to one lifetime row each, with no guest rows in permanent rankings.
+
+**Acceptance Scenarios (Gherkin style)**:
+
+1. **Given** completed sessions with repeated participation by the same registered account, **When** lifetime stats are requested, **Then** the same account is aggregated into one durable stats record.
+2. **Given** a user with no completed sessions, **When** lifetime stats are requested, **Then** the response is empty or zeroed rather than failing.
+3. **Given** guest participants appear in completed sessions, **When** lifetime stats are requested, **Then** the guest identities are not promoted into durable lifetime rows.
+
+---
+
+### User Story 3 - Player Comparisons Are Stable And Session-Safe (Priority: P2)
+
+As a player comparing two users, I can load head-to-head comparison data, with registered users compared across completed sessions and guest participants kept session-scoped, so the client can render the comparison view without calculating the metrics locally.
+
+**Why this priority**: Comparison data is more specialized than history and lifetime stats, but it still needs a stable contract so the current client comparison logic can move off local aggregation.
+
+**Independent Test**: Request comparison data for two selected participants and confirm the response covers the metrics currently shown in the comparison modal.
+
+**Acceptance Scenarios (Gherkin style)**:
+
+1. **Given** two registered users with shared completed sessions, **When** a comparison is requested, **Then** the response includes shared-session counts, wins and ties, per-player totals, averages, peak single-session totals, per-match efficiency, top-drinker frequency, and trend data needed by the comparison view.
+2. **Given** a registered user and a guest participant from the same completed session, **When** a comparison is requested, **Then** the response includes the same comparison metrics for that session snapshot while keeping the guest scoped to that session.
+3. **Given** two registered users with no shared completed sessions, **When** a comparison is requested, **Then** the response returns zero shared-session metrics, an empty timeline, and the per-player totals for each user.
+4. **Given** the same pair and dataset, **When** the comparison is requested again, **Then** the results are deterministic and use the same identity keys.
+5. **Given** a guest participant appears only in session history, **When** comparison data is built, **Then** the guest remains session-scoped and is not treated as a durable ranked identity.
+6. **Given** a guest participant and a registered user do not appear together in the same completed session snapshot, **When** a comparison is requested, **Then** the system rejects the comparison rather than inventing cross-session guest identity.
+
+---
+
+### User Story 4 - Leaderboards Rank Registered Users Only (Priority: P2)
+
+As a player viewing leaderboards, I can see ranked registered users by total drinks consumed in completed sessions with a deterministic tie-break, so permanent rankings stay consistent and do not mix in session-scoped guests.
+
+**Why this priority**: Leaderboards need durable identities and stable ordering, while guests should remain tied to the session where they appeared.
+
+**Independent Test**: Request a leaderboard from completed-session data and verify that only registered accounts are present, ordered by total drinks consumed, then average drinks per game, then account ID.
+
+**Acceptance Scenarios (Gherkin style)**:
+
+1. **Given** a dataset with registered users and guest participants, **When** the leaderboard is requested, **Then** only registered accounts appear in the ranking and they are ordered by total drinks consumed, then average drinks per game, then account ID.
+2. **Given** tied ranking values, **When** the leaderboard is requested repeatedly, **Then** the ordering is deterministic for the same dataset.
+3. **Given** a user has no completed sessions, **When** the leaderboard is requested, **Then** that user does not appear as a ranked entry.
+
+---
+
+### Edge Cases
+
+- A completed session has no guest participants.
+- A completed session has no registered participants.
+- Two different registered accounts share the same display name.
+- A session includes zero or incomplete matches, so summary fields must still be well-defined.
+- A comparison is requested for players who never appeared in the same session; the response should still be stable and should not invent session-scoped overlap.
+- The same dataset is queried after new unrelated completed sessions are added; each read model must continue to return the same result for the same underlying scope.
+
+## Platform & State Impact _(mandatory when applicable)_
+
+- **Platform Behavior**: Native and web clients should use the same derived data contract; the read models themselves are platform-neutral.
+- **Shared State Model**: The shared multiplayer data store remains the canonical source of truth for completed-session history and all derived lifetime or ranking outputs. The client should stop recalculating these aggregates locally once the read models are consumed.
+- **Identity Model**: Durable lifetime stats and leaderboards are keyed by registered account identity. Guest participants remain session-scoped and only appear in per-session history summaries.
+- **Migration / Backfill**: Existing completed session data is the source of truth for the new read models. No separate data migration or identity backfill is expected in this story.
+
+## Delivery & Automation Impact _(mandatory)_
+
+- **Unit Test Coverage**: Add database-level tests that validate history summaries, lifetime stats, comparison results, leaderboard ordering, stable result shapes, and guest exclusion from durable rankings.
+- **E2E Test Coverage**: No new end-to-end flow is required for this story unless the client integration is included in the same change set. The primary validation remains at the read-model and query-contract level.
+- **Applicable Skills**: supabase, supabase-postgres-best-practices, database-design-expert, database-testing
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a stable history summary for completed sessions that includes the data needed to render session lists and details without client-side aggregation.
+- **FR-002**: The system MUST key history summaries for registered participants to durable account identity where appropriate, while preserving guest participants only as session-scoped records.
+- **FR-003**: The system MUST provide lifetime statistics for registered users across completed sessions using one durable record per account.
+- **FR-004**: The system MUST provide a comparison read model for any two registered users across completed sessions, and for guest session participants only when both participants appear in the same completed session snapshot, that includes the metrics needed for head-to-head and influence views without requiring the client to recompute them, and returns zero shared-session metrics plus an empty timeline when the compared registered users have no shared completed sessions.
+- **FR-005**: The system MUST provide a leaderboard read model for registered users that ranks by total drinks consumed in completed sessions, breaks ties by higher average drinks per game and then account ID ascending, supports stable ranking, and excludes guest identities from permanent rankings.
+- **FR-006**: The system MUST return empty or zeroed results, rather than errors, when a user has no completed-session history or when a leaderboard scope has no ranked participants.
+- **FR-007**: The system MUST keep guest participants session-scoped in derived reads and MUST NOT promote them into durable lifetime or leaderboard identities in v1.
+- **FR-008**: The system MUST return the same read-model shape and ordering for the same underlying dataset and query scope.
+- **FR-009**: The system MUST document the response shape for each read model so the client can consume it without additional aggregation logic.
+- **FR-010**: The system MUST validate the read-model behavior against representative completed-session datasets and benchmark the query behavior before the feature is considered complete.
+
+### Key Entities _(include if feature involves data)_
+
+- **Completed Session Summary**: A per-session derived record that captures the session identity, participants, matches, completion timing, and summary totals needed by history views.
+- **Lifetime Player Stat**: A registered-user aggregate that combines completed-session participation into durable totals, averages, and counts.
+- **Player Comparison**: A derived head-to-head summary for two selected participants that captures shared-session metrics and trend data, including guest session participants when the comparison is scoped to a session snapshot.
+- **Leaderboard Entry**: A ranked registered-user summary used to display ordered lifetime performance results by total drinks consumed with average-drinks-per-game tie-breaking.
+- **Registered Identity**: A durable account-linked identity that can appear in lifetime stats and leaderboards.
+- **Guest Session Participant**: A session-scoped identity that may appear inside a session summary but does not become a permanent ranked identity.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: In validation with completed-session datasets, the history screen can load session summaries without client-side aggregation in 100% of sampled runs.
+- **SC-002**: In validation, every registered user with completed-session participation is represented by one lifetime stats record keyed to their account identity.
+- **SC-003**: In validation, guest participants never appear as permanent lifetime or leaderboard identities, while still appearing inside the session summaries where they belong.
+- **SC-004**: In validation, repeated comparison requests for the same two selected participants and the same dataset return identical results in 100% of runs.
+- **SC-005**: In validation, leaderboards ordered by total drinks consumed and average drinks per game return deterministic ordering for tied results and remain stable across repeated queries for the same dataset.
+- **SC-006**: Benchmark validation shows the representative read-model queries complete within the agreed local-performance threshold for the sample completed-session dataset.
+
+## Assumptions
+
+- Completed multiplayer sessions are the only source used to build the new read models in v1.
+- Registered account identity is the durable key for lifetime stats and leaderboard rankings, and leaderboard ordering uses total drinks consumed in completed sessions with average drinks per game as the tie-break.
+- Guest participants remain session-scoped and are not backfilled into permanent identity tables for this story.
+- The current history screen's session, player, stats, and comparison views define the minimum contract the read models must support, including session-scoped guest comparisons only when both participants are present in the same completed session snapshot and cross-session comparisons for registered users.
+- No separate data cleanup or migration is required beyond deriving these read models from existing completed-session data.

--- a/specs/009-history-read-models/tasks.md
+++ b/specs/009-history-read-models/tasks.md
@@ -1,0 +1,201 @@
+# Tasks: History, Comparison, and Leaderboard Read Models
+
+**Input**: Design documents from `specs/009-history-read-models/`  
+**Prerequisites**: `plan.md` (required), `spec.md` (required for user stories), `research.md`, `data-model.md`, `contracts/`, `quickstart.md`
+
+**Tests**: This feature requires pgTAP coverage for the new SQL surfaces and query behavior. No UI end-to-end coverage is required because the feature stays in the Supabase database layer.
+
+**Organization**: Tasks are grouped by user story so each slice can be implemented and validated independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to, for example `US1`, `US2`, or `US3`
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the migration and pgTAP scaffolds for the new read-model slice.
+
+- [x] T001 [P] Create migration scaffolds in `supabase/migrations/018_history_read_models_support.sql`, `supabase/migrations/019_history_read_models_history.sql`, `supabase/migrations/020_history_read_models_lifetime.sql`, `supabase/migrations/021_history_read_models_comparisons.sql`, and `supabase/migrations/022_history_read_models_leaderboard.sql`
+- [x] T002 [P] Create pgTAP scaffolds in `supabase/tests/database/070_history_read_models_history.test.sql`, `supabase/tests/database/080_history_read_models_lifetime.test.sql`, `supabase/tests/database/090_history_read_models_comparisons.test.sql`, `supabase/tests/database/100_history_read_models_leaderboard.test.sql`, and `supabase/tests/database/110_history_read_models_performance.test.sql`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add the shared completed-session rollup primitives that every read model builds on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [x] T003 Add shared internal rollup views/functions in `supabase/migrations/018_history_read_models_support.sql` that normalize completed-session filtering, participant rows, match rows, assignment rows, and reusable comparison inputs for later read models
+
+**Checkpoint**: The shared read-model primitives exist and the story-specific views/functions can now be built on top of them.
+
+---
+
+## Phase 3: User Story 1 - Completed History Loads Without Local Recalculation (Priority: P1) 🎯 MVP
+
+**Goal**: A player opening History can load completed session summaries and overview totals from the database without recomputing them on the client.
+
+**Independent Test**: Load representative completed sessions and confirm the returned summary data includes the session identity, nested participants, matches, assignments, completion timing, and totals needed to render the Games and Stats tabs.
+
+### Tests for User Story 1 (REQUIRED coverage) ⚠️
+
+- [x] T004 [P] [US1] Add pgTAP coverage in `supabase/tests/database/070_history_read_models_history.test.sql` for completed-session summary shape, nested participant/match/assignment data, guest scoping, and stable ordering
+
+### Implementation for User Story 1
+
+- [x] T005 [US1] Implement `public.completed_session_summaries` and `public.history_overview_totals` in `supabase/migrations/019_history_read_models_history.sql`, using the shared helpers from `supabase/migrations/018_history_read_models_support.sql` and granting authenticated read access
+
+**Checkpoint**: User Story 1 is independently testable and the database can serve the History screen data without client-side aggregation.
+
+---
+
+## Phase 4: User Story 2 - Lifetime Stats Stay Keyed To Registered Identity (Priority: P1)
+
+**Goal**: Signed-in players can load durable lifetime totals across completed sessions, with one row per registered account and no guest rows in permanent rankings.
+
+**Independent Test**: Query multiple completed sessions and confirm each registered account aggregates into one lifetime row while guest participants remain excluded.
+
+### Tests for User Story 2 (REQUIRED coverage) ⚠️
+
+- [x] T006 [P] [US2] Add pgTAP coverage in `supabase/tests/database/080_history_read_models_lifetime.test.sql` for one-row-per-account aggregation, guest exclusion, empty-state behavior, and stable totals
+
+### Implementation for User Story 2
+
+- [x] T007 [US2] Implement `public.lifetime_player_stats` in `supabase/migrations/020_history_read_models_lifetime.sql` from the shared completed-session rollups and registered account identity keys, with authenticated read access
+
+**Checkpoint**: User Story 2 is independently testable and durable lifetime totals are available for the Players and Stats tabs.
+
+---
+
+## Phase 5: User Story 3 - Player Comparisons Are Stable And Session-Safe (Priority: P2)
+
+**Goal**: Players can load head-to-head comparison data from the database, with registered users compared across completed sessions and guest participants kept session-scoped.
+
+**Independent Test**: Request comparison data for two selected participants and confirm the response covers the metrics currently shown in the comparison modal, including the no-overlap registered-user case and the same-session guest case.
+
+### Tests for User Story 3 (REQUIRED coverage) ⚠️
+
+- [x] T008 [P] [US3] Add pgTAP coverage in `supabase/tests/database/090_history_read_models_comparisons.test.sql` for registered-user comparisons, same-session guest comparisons, zero-overlap fallback, and deterministic timeline ordering
+
+### Implementation for User Story 3
+
+- [x] T009 [US3] Implement `public.compare_registered_players` and `public.compare_session_participants` in `supabase/migrations/021_history_read_models_comparisons.sql`, using the shared helpers and the spec's guest-scope rules, with authenticated execute access
+
+**Checkpoint**: User Story 3 is independently testable and comparison reads no longer rely on client-side aggregation.
+
+---
+
+## Phase 6: User Story 4 - Leaderboards Rank Registered Users Only (Priority: P2)
+
+**Goal**: Leaderboards show registered users ranked by total drinks consumed in completed sessions, with deterministic tie-breaks and no guest identities in permanent rankings.
+
+**Independent Test**: Request the leaderboard from completed-session data and verify only registered accounts appear, ordered by total drinks, then average drinks per game, then account ID.
+
+### Tests for User Story 4 (REQUIRED coverage) ⚠️
+
+- [x] T010 [P] [US4] Add pgTAP coverage in `supabase/tests/database/100_history_read_models_leaderboard.test.sql` for rank ordering, tie-breaks, zero-result handling, and guest exclusion
+
+### Implementation for User Story 4
+
+- [x] T011 [US4] Implement `public.leaderboard_entries` in `supabase/migrations/022_history_read_models_leaderboard.sql` from `public.lifetime_player_stats`, preserving the total-drinks, average-per-game, and `account_id` ordering rules
+
+**Checkpoint**: User Story 4 is independently testable and the leaderboard now comes from the database instead of local sorting.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation, performance checks, and documentation alignment.
+
+- [x] T012 [P] Add pgTAP performance checks in `supabase/tests/database/110_history_read_models_performance.test.sql` with `EXPLAIN (ANALYZE, BUFFERS)` assertions for the completed-session history, lifetime stats, comparison, and leaderboard read paths
+- [x] T013 [P] Run `npx --yes supabase db reset` and `npx --yes supabase test db` to validate the full read-model slice against `supabase/migrations/` and `supabase/tests/database/`
+- [x] T014 [P] Update `specs/009-history-read-models/quickstart.md` so the documented migration and test filenames match the final implementation layout and the validation steps stay accurate
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3+)**: Each depends on Foundational completion; US1, US2, and US3 can proceed independently after Phase 2, while US4 depends on the lifetime-stats work from US2
+- **Polish (Final Phase)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational - no dependency on other stories
+- **User Story 2 (P1)**: Can start after Foundational - no dependency on US1, but its output is reused by US4
+- **User Story 3 (P2)**: Can start after Foundational - independent of US1 and US2
+- **User Story 4 (P2)**: Can start after US2 because it derives from `public.lifetime_player_stats`
+
+### Within Each User Story
+
+- Required tests MUST be written and FAIL before implementation
+- Different story phases can be worked on in parallel once the shared foundation exists
+- Each implementation task stays inside its named migration file so the SQL surface remains easy to review and test
+- Performance validation is deferred to the polish phase once the main SQL surfaces exist
+
+### Parallel Opportunities
+
+- **Phase 1**: T001 and T002 can run in parallel
+- **Phase 3-6 Tests**: T004, T006, T008, and T010 can be prepared in parallel because they touch different test files
+- **Phase 3-6 Implementation**: T005, T007, and T009 can be implemented in parallel after T003 because they touch different migration files; T011 follows after US2 because the leaderboard reuses lifetime stats
+- **Phase 7**: T012, T013, and T014 can run independently once the SQL surfaces are complete
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. **STOP and VALIDATE**: Confirm the History data contract works independently
+5. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Finish Setup + Foundational so the shared completed-session primitives exist
+2. Deliver User Story 1 to remove local history aggregation
+3. Deliver User Story 2 to supply durable lifetime stats
+4. Deliver User Story 3 to supply stable comparison reads
+5. Deliver User Story 4 to rank registered users in the database
+6. Run the quickstart smoke checklist and the full pgTAP suite before merge
+
+### Parallel Team Strategy
+
+With multiple contributors:
+
+1. Split Setup and Foundational file creation early
+2. After Phase 2, assign one contributor to US1 history views/tests, one to US2 lifetime stats/tests, one to US3 comparisons/tests, and one to US4 leaderboard work once US2 lands
+3. Validate each user story independently as soon as its tests and SQL are complete
+
+---
+
+## Summary
+
+| Phase                  | Story | Tasks         | Parallel Opportunities |
+| ---------------------- | ----- | ------------- | ---------------------- |
+| 1 - Setup              | -     | T001-T002 (2) | T001 + T002            |
+| 2 - Foundational       | -     | T003 (1)      | -                      |
+| 3 - US1 History        | P1    | T004-T005 (2) | T004                   |
+| 4 - US2 Lifetime Stats | P1    | T006-T007 (2) | T006                   |
+| 5 - US3 Comparisons    | P2    | T008-T009 (2) | T008                   |
+| 6 - US4 Leaderboard    | P2    | T010-T011 (2) | T010                   |
+| 7 - Polish             | -     | T012-T014 (3) | T012 + T013 + T014     |
+| **Total**              |       | **14**        |                        |
+
+---
+
+## Notes
+
+- [P] tasks can be executed in parallel when they touch different files and do not depend on incomplete work
+- Each story is independently testable once its tasks are complete
+- Keep the read-model work in Supabase migrations and pgTAP tests; the client integration can land in a later story once these contracts are stable

--- a/supabase/migrations/018_history_read_models_support.sql
+++ b/supabase/migrations/018_history_read_models_support.sql
@@ -1,0 +1,151 @@
+-- 018_history_read_models_support.sql
+-- Shared private rollups for the history read models.
+CREATE OR REPLACE VIEW private._history_account_display_names AS
+SELECT accounts.id AS account_id,
+    accounts.preferred_display_name
+FROM public.accounts accounts;
+CREATE OR REPLACE VIEW private._history_completed_sessions AS
+SELECT game_sessions.id AS session_id,
+    game_sessions.host_account_id,
+    game_sessions.started_at,
+    game_sessions.completed_at,
+    game_sessions.common_match_id
+FROM public.game_sessions game_sessions
+WHERE game_sessions.state = 'completed';
+CREATE OR REPLACE VIEW private._history_completed_participants AS
+SELECT participants.session_id,
+    participants.id AS participant_id,
+    participants.account_id,
+    participants.display_name,
+    participants.membership_type,
+    participants.current_drink_total,
+    participants.created_at,
+    account_names.preferred_display_name AS account_display_name
+FROM public.participants participants
+    JOIN private._history_completed_sessions completed_sessions ON completed_sessions.session_id = participants.session_id
+    LEFT JOIN private._history_account_display_names account_names ON account_names.account_id = participants.account_id;
+CREATE OR REPLACE VIEW private._history_completed_matches AS
+SELECT matches.session_id,
+    matches.id AS match_id,
+    matches.source_provider,
+    matches.source_match_id,
+    matches.home_team_name,
+    matches.away_team_name,
+    matches.kickoff_at,
+    matches.home_score,
+    matches.away_score,
+    matches.created_at,
+    (matches.home_score + matches.away_score) AS total_goals
+FROM public.matches matches
+    JOIN private._history_completed_sessions completed_sessions ON completed_sessions.session_id = matches.session_id;
+CREATE OR REPLACE VIEW private._history_completed_assignments AS
+SELECT assignments.session_id,
+    assignments.participant_id,
+    assignments.match_id,
+    assignments.created_at
+FROM public.assignments assignments
+    JOIN private._history_completed_sessions completed_sessions ON completed_sessions.session_id = assignments.session_id;
+CREATE OR REPLACE VIEW private._history_session_rollups AS
+SELECT completed_sessions.session_id,
+    completed_sessions.host_account_id,
+    completed_sessions.started_at,
+    completed_sessions.completed_at,
+    completed_sessions.common_match_id,
+    COALESCE(participant_counts.session_total_players, 0)::integer AS session_total_players,
+    COALESCE(match_counts.session_total_matches, 0)::integer AS session_total_matches,
+    COALESCE(match_counts.session_total_goals, 0)::integer AS session_total_goals,
+    COALESCE(participant_counts.session_total_drinks, 0)::numeric AS session_total_drinks,
+    CASE
+        WHEN COALESCE(participant_counts.session_total_players, 0) > 0 THEN COALESCE(match_counts.session_total_matches, 0)::numeric / participant_counts.session_total_players
+        ELSE 0
+    END AS matches_per_player
+FROM private._history_completed_sessions completed_sessions
+    LEFT JOIN LATERAL (
+        SELECT count(*)::integer AS session_total_players,
+            COALESCE(sum(participants.current_drink_total), 0)::numeric AS session_total_drinks
+        FROM private._history_completed_participants participants
+        WHERE participants.session_id = completed_sessions.session_id
+    ) participant_counts ON TRUE
+    LEFT JOIN LATERAL (
+        SELECT count(*)::integer AS session_total_matches,
+            COALESCE(sum(matches.total_goals), 0)::integer AS session_total_goals
+        FROM private._history_completed_matches matches
+        WHERE matches.session_id = completed_sessions.session_id
+    ) match_counts ON TRUE;
+CREATE OR REPLACE VIEW private._history_participant_session_rollups AS
+SELECT participants.session_id,
+    participants.participant_id,
+    participants.account_id,
+    participants.display_name,
+    participants.account_display_name,
+    participants.membership_type,
+    participants.current_drink_total,
+    participants.created_at,
+    completed_sessions.completed_at,
+    completed_sessions.common_match_id,
+    COALESCE(match_counts.session_match_count, 0)::integer AS session_match_count,
+    COALESCE(participant_counts.session_participant_count, 0)::integer AS session_participant_count,
+    COALESCE(session_max.session_max_drinks, 0)::numeric AS session_max_drinks,
+    CASE
+        WHEN participants.current_drink_total = COALESCE(session_max.session_max_drinks, 0) THEN TRUE
+        ELSE FALSE
+    END AS is_top_drinker
+FROM private._history_completed_participants participants
+    JOIN private._history_completed_sessions completed_sessions ON completed_sessions.session_id = participants.session_id
+    LEFT JOIN LATERAL (
+        SELECT count(*)::integer AS session_match_count
+        FROM private._history_completed_matches matches
+        WHERE matches.session_id = participants.session_id
+    ) match_counts ON TRUE
+    LEFT JOIN LATERAL (
+        SELECT count(*)::integer AS session_participant_count
+        FROM private._history_completed_participants other_participants
+        WHERE other_participants.session_id = participants.session_id
+    ) participant_counts ON TRUE
+    LEFT JOIN LATERAL (
+        SELECT max(other_participants.current_drink_total)::numeric AS session_max_drinks
+        FROM private._history_completed_participants other_participants
+        WHERE other_participants.session_id = participants.session_id
+    ) session_max ON TRUE;
+REVOKE ALL ON TABLE private._history_account_display_names
+FROM PUBLIC,
+    anon,
+    authenticated;
+GRANT SELECT ON TABLE private._history_account_display_names TO authenticated,
+    service_role;
+REVOKE ALL ON TABLE private._history_completed_sessions
+FROM PUBLIC,
+    anon,
+    authenticated;
+GRANT SELECT ON TABLE private._history_completed_sessions TO authenticated,
+    service_role;
+REVOKE ALL ON TABLE private._history_completed_participants
+FROM PUBLIC,
+    anon,
+    authenticated;
+GRANT SELECT ON TABLE private._history_completed_participants TO authenticated,
+    service_role;
+REVOKE ALL ON TABLE private._history_completed_matches
+FROM PUBLIC,
+    anon,
+    authenticated;
+GRANT SELECT ON TABLE private._history_completed_matches TO authenticated,
+    service_role;
+REVOKE ALL ON TABLE private._history_completed_assignments
+FROM PUBLIC,
+    anon,
+    authenticated;
+GRANT SELECT ON TABLE private._history_completed_assignments TO authenticated,
+    service_role;
+REVOKE ALL ON TABLE private._history_session_rollups
+FROM PUBLIC,
+    anon,
+    authenticated;
+GRANT SELECT ON TABLE private._history_session_rollups TO authenticated,
+    service_role;
+REVOKE ALL ON TABLE private._history_participant_session_rollups
+FROM PUBLIC,
+    anon,
+    authenticated;
+GRANT SELECT ON TABLE private._history_participant_session_rollups TO authenticated,
+    service_role;

--- a/supabase/migrations/019_history_read_models_history.sql
+++ b/supabase/migrations/019_history_read_models_history.sql
@@ -1,0 +1,115 @@
+-- 019_history_read_models_history.sql
+-- Completed history summaries and overview totals.
+CREATE OR REPLACE VIEW public.completed_session_summaries WITH (security_invoker = true) AS
+SELECT session_rollups.session_id,
+    session_rollups.host_account_id,
+    session_rollups.completed_at,
+    session_rollups.started_at,
+    session_rollups.common_match_id,
+    session_rollups.session_total_players,
+    session_rollups.session_total_matches,
+    session_rollups.session_total_goals,
+    session_rollups.session_total_drinks,
+    session_rollups.matches_per_player,
+    COALESCE(players.players, '[]'::jsonb) AS players,
+    COALESCE(matches.matches, '[]'::jsonb) AS matches,
+    COALESCE(assignments.player_assignments, '{}'::jsonb) AS player_assignments
+FROM private._history_session_rollups session_rollups
+    LEFT JOIN LATERAL (
+        SELECT COALESCE(
+                jsonb_agg(
+                    jsonb_build_object(
+                        'id',
+                        participants.participant_id,
+                        'accountId',
+                        participants.account_id,
+                        'name',
+                        participants.display_name,
+                        'drinksTaken',
+                        participants.current_drink_total,
+                        'membershipType',
+                        participants.membership_type
+                    )
+                    ORDER BY participants.created_at,
+                        participants.participant_id
+                ),
+                '[]'::jsonb
+            ) AS players
+        FROM private._history_completed_participants participants
+        WHERE participants.session_id = session_rollups.session_id
+    ) players ON TRUE
+    LEFT JOIN LATERAL (
+        SELECT COALESCE(
+                jsonb_agg(
+                    jsonb_build_object(
+                        'id',
+                        matches.match_id,
+                        'sourceProvider',
+                        matches.source_provider,
+                        'sourceMatchId',
+                        matches.source_match_id,
+                        'homeTeam',
+                        matches.home_team_name,
+                        'awayTeam',
+                        matches.away_team_name,
+                        'kickoffAt',
+                        matches.kickoff_at,
+                        'homeGoals',
+                        matches.home_score,
+                        'awayGoals',
+                        matches.away_score,
+                        'goals',
+                        matches.total_goals
+                    )
+                    ORDER BY matches.created_at,
+                        matches.match_id
+                ),
+                '[]'::jsonb
+            ) AS matches
+        FROM private._history_completed_matches matches
+        WHERE matches.session_id = session_rollups.session_id
+    ) matches ON TRUE
+    LEFT JOIN LATERAL (
+        SELECT COALESCE(
+                jsonb_object_agg(
+                    assignment_groups.participant_id::text,
+                    assignment_groups.match_ids
+                ),
+                '{}'::jsonb
+            ) AS player_assignments
+        FROM (
+                SELECT assignments.participant_id,
+                    jsonb_agg(
+                        assignments.match_id::text
+                        ORDER BY assignments.match_id
+                    ) AS match_ids
+                FROM private._history_completed_assignments assignments
+                WHERE assignments.session_id = session_rollups.session_id
+                GROUP BY assignments.participant_id
+            ) assignment_groups
+    ) assignments ON TRUE
+ORDER BY session_rollups.completed_at DESC,
+    session_rollups.session_id DESC;
+REVOKE ALL ON TABLE public.completed_session_summaries
+FROM PUBLIC,
+    anon,
+    authenticated;
+GRANT SELECT ON TABLE public.completed_session_summaries TO authenticated,
+    service_role;
+CREATE OR REPLACE VIEW public.history_overview_totals WITH (security_invoker = true) AS
+SELECT COALESCE(count(*), 0)::integer AS total_sessions,
+    COALESCE(sum(session_total_players), 0)::integer AS total_participations,
+    COALESCE(sum(session_total_matches), 0)::integer AS total_matches,
+    COALESCE(sum(session_total_goals), 0)::integer AS total_goals,
+    COALESCE(sum(session_total_drinks), 0)::numeric AS total_drinks,
+    CASE
+        WHEN COALESCE(sum(session_total_players), 0) > 0 THEN COALESCE(sum(session_total_drinks), 0)::numeric / sum(session_total_players)
+        ELSE 0
+    END AS average_drinks_per_participation
+FROM public.completed_session_summaries;
+REVOKE ALL ON TABLE public.history_overview_totals
+FROM PUBLIC,
+    anon,
+    authenticated;
+GRANT SELECT ON TABLE public.history_overview_totals TO authenticated,
+    service_role;

--- a/supabase/migrations/020_history_read_models_lifetime.sql
+++ b/supabase/migrations/020_history_read_models_lifetime.sql
@@ -1,0 +1,26 @@
+-- 020_history_read_models_lifetime.sql
+-- Lifetime player stats derived from completed-session participant rollups.
+CREATE OR REPLACE VIEW public.lifetime_player_stats WITH (security_invoker = true) AS
+SELECT participants.account_id,
+    COALESCE(
+        MAX(participants.account_display_name),
+        MAX(participants.display_name)
+    ) AS display_name,
+    count(DISTINCT participants.session_id)::integer AS games_played,
+    COALESCE(sum(participants.current_drink_total), 0)::numeric AS total_drinks,
+    CASE
+        WHEN count(DISTINCT participants.session_id) > 0 THEN COALESCE(sum(participants.current_drink_total), 0)::numeric / count(DISTINCT participants.session_id)
+        ELSE 0
+    END AS average_per_game
+FROM private._history_participant_session_rollups participants
+WHERE participants.account_id IS NOT NULL
+GROUP BY participants.account_id
+ORDER BY total_drinks DESC,
+    average_per_game DESC,
+    account_id ASC;
+REVOKE ALL ON TABLE public.lifetime_player_stats
+FROM PUBLIC,
+    anon,
+    authenticated;
+GRANT SELECT ON TABLE public.lifetime_player_stats TO authenticated,
+    service_role;

--- a/supabase/migrations/021_history_read_models_comparisons.sql
+++ b/supabase/migrations/021_history_read_models_comparisons.sql
@@ -1,0 +1,518 @@
+-- 021_history_read_models_comparisons.sql
+-- Comparison read-model functions for registered users and session-scoped guest participants.
+CREATE OR REPLACE FUNCTION public.compare_registered_players(
+        left_account_id uuid,
+        right_account_id uuid
+    ) RETURNS TABLE (
+        player1_id uuid,
+        player2_id uuid,
+        player1_name text,
+        player2_name text,
+        player1_games_played integer,
+        player2_games_played integer,
+        player1_total_drinks numeric,
+        player2_total_drinks numeric,
+        player1_average_per_game numeric,
+        player2_average_per_game numeric,
+        games_played_together integer,
+        player1_wins_count integer,
+        player2_wins_count integer,
+        tied_games_count integer,
+        player1_max_in_a_game numeric,
+        player2_max_in_a_game numeric,
+        player1_common_match_count integer,
+        player2_common_match_count integer,
+        player1_efficiency numeric,
+        player2_efficiency numeric,
+        player1_top_drinker_count integer,
+        player2_top_drinker_count integer,
+        player1_avg_with_player2 numeric,
+        player1_avg_without_player2 numeric,
+        player2_avg_with_player1 numeric,
+        player2_avg_without_player1 numeric,
+        timeline_data jsonb
+    ) LANGUAGE sql STABLE AS $$ WITH left_games AS (
+        SELECT participants.session_id,
+            participants.completed_at,
+            participants.current_drink_total,
+            participants.common_match_id,
+            participants.session_match_count,
+            participants.is_top_drinker
+        FROM private._history_participant_session_rollups participants
+        WHERE participants.account_id = left_account_id
+    ),
+    right_games AS (
+        SELECT participants.session_id,
+            participants.completed_at,
+            participants.current_drink_total,
+            participants.common_match_id,
+            participants.session_match_count,
+            participants.is_top_drinker
+        FROM private._history_participant_session_rollups participants
+        WHERE participants.account_id = right_account_id
+    ),
+    shared_games AS (
+        SELECT left_games.session_id,
+            left_games.completed_at,
+            left_games.current_drink_total AS player1_drinks,
+            right_games.current_drink_total AS player2_drinks
+        FROM left_games
+            INNER JOIN right_games USING (session_id)
+    ),
+    left_without_games AS (
+        SELECT left_games.*
+        FROM left_games
+            LEFT JOIN shared_games USING (session_id)
+        WHERE shared_games.session_id IS NULL
+    ),
+    right_without_games AS (
+        SELECT right_games.*
+        FROM right_games
+            LEFT JOIN shared_games USING (session_id)
+        WHERE shared_games.session_id IS NULL
+    ),
+    left_totals AS (
+        SELECT count(*)::integer AS games_played,
+            COALESCE(sum(current_drink_total), 0)::numeric AS total_drinks,
+            COALESCE(sum(session_match_count), 0)::integer AS total_matches,
+            COALESCE(max(current_drink_total), 0)::numeric AS max_in_a_game,
+            COALESCE(
+                count(*) FILTER (
+                    WHERE common_match_id IS NOT NULL
+                ),
+                0
+            )::integer AS common_match_count,
+            COALESCE(
+                count(*) FILTER (
+                    WHERE is_top_drinker
+                ),
+                0
+            )::integer AS top_drinker_count
+        FROM left_games
+    ),
+    right_totals AS (
+        SELECT count(*)::integer AS games_played,
+            COALESCE(sum(current_drink_total), 0)::numeric AS total_drinks,
+            COALESCE(sum(session_match_count), 0)::integer AS total_matches,
+            COALESCE(max(current_drink_total), 0)::numeric AS max_in_a_game,
+            COALESCE(
+                count(*) FILTER (
+                    WHERE common_match_id IS NOT NULL
+                ),
+                0
+            )::integer AS common_match_count,
+            COALESCE(
+                count(*) FILTER (
+                    WHERE is_top_drinker
+                ),
+                0
+            )::integer AS top_drinker_count
+        FROM right_games
+    )
+SELECT left_account_id AS player1_id,
+    right_account_id AS player2_id,
+    COALESCE(
+        (
+            SELECT preferred_display_name
+            FROM private._history_account_display_names
+            WHERE account_id = left_account_id
+        ),
+        left_account_id::text
+    ) AS player1_name,
+    COALESCE(
+        (
+            SELECT preferred_display_name
+            FROM private._history_account_display_names
+            WHERE account_id = right_account_id
+        ),
+        right_account_id::text
+    ) AS player2_name,
+    left_totals.games_played AS player1_games_played,
+    right_totals.games_played AS player2_games_played,
+    left_totals.total_drinks AS player1_total_drinks,
+    right_totals.total_drinks AS player2_total_drinks,
+    CASE
+        WHEN left_totals.games_played > 0 THEN left_totals.total_drinks / left_totals.games_played
+        ELSE 0
+    END AS player1_average_per_game,
+    CASE
+        WHEN right_totals.games_played > 0 THEN right_totals.total_drinks / right_totals.games_played
+        ELSE 0
+    END AS player2_average_per_game,
+    COALESCE(
+        (
+            SELECT count(*)::integer
+            FROM shared_games
+        ),
+        0
+    ) AS games_played_together,
+    COALESCE(
+        (
+            SELECT count(*)::integer
+            FROM shared_games
+            WHERE player1_drinks > player2_drinks
+        ),
+        0
+    ) AS player1_wins_count,
+    COALESCE(
+        (
+            SELECT count(*)::integer
+            FROM shared_games
+            WHERE player2_drinks > player1_drinks
+        ),
+        0
+    ) AS player2_wins_count,
+    COALESCE(
+        (
+            SELECT count(*)::integer
+            FROM shared_games
+            WHERE player1_drinks = player2_drinks
+        ),
+        0
+    ) AS tied_games_count,
+    left_totals.max_in_a_game AS player1_max_in_a_game,
+    right_totals.max_in_a_game AS player2_max_in_a_game,
+    left_totals.common_match_count AS player1_common_match_count,
+    right_totals.common_match_count AS player2_common_match_count,
+    CASE
+        WHEN left_totals.total_matches > 0 THEN left_totals.total_drinks / left_totals.total_matches
+        ELSE 0
+    END AS player1_efficiency,
+    CASE
+        WHEN right_totals.total_matches > 0 THEN right_totals.total_drinks / right_totals.total_matches
+        ELSE 0
+    END AS player2_efficiency,
+    left_totals.top_drinker_count AS player1_top_drinker_count,
+    right_totals.top_drinker_count AS player2_top_drinker_count,
+    COALESCE(
+        (
+            SELECT CASE
+                    WHEN count(*) > 0 THEN sum(player1_drinks) / count(*)
+                    ELSE 0
+                END
+            FROM shared_games
+        ),
+        0
+    ) AS player1_avg_with_player2,
+    COALESCE(
+        (
+            SELECT CASE
+                    WHEN count(*) > 0 THEN sum(current_drink_total) / count(*)
+                    ELSE 0
+                END
+            FROM left_without_games
+        ),
+        0
+    ) AS player1_avg_without_player2,
+    COALESCE(
+        (
+            SELECT CASE
+                    WHEN count(*) > 0 THEN sum(player2_drinks) / count(*)
+                    ELSE 0
+                END
+            FROM shared_games
+        ),
+        0
+    ) AS player2_avg_with_player1,
+    COALESCE(
+        (
+            SELECT CASE
+                    WHEN count(*) > 0 THEN sum(current_drink_total) / count(*)
+                    ELSE 0
+                END
+            FROM right_without_games
+        ),
+        0
+    ) AS player2_avg_without_player1,
+    COALESCE(
+        (
+            SELECT jsonb_agg(
+                    jsonb_build_object(
+                        'date',
+                        completed_at::text,
+                        'player1Drinks',
+                        player1_drinks,
+                        'player2Drinks',
+                        player2_drinks
+                    )
+                    ORDER BY completed_at,
+                        session_id
+                )
+            FROM shared_games
+        ),
+        '[]'::jsonb
+    ) AS timeline_data
+FROM left_totals,
+    right_totals;
+$$;
+REVOKE ALL ON FUNCTION public.compare_registered_players(uuid, uuid)
+FROM PUBLIC,
+    anon,
+    authenticated;
+GRANT EXECUTE ON FUNCTION public.compare_registered_players(uuid, uuid) TO authenticated,
+    service_role;
+CREATE OR REPLACE FUNCTION public.compare_session_participants(
+        p_session_id uuid,
+        p_left_participant_id uuid,
+        p_right_participant_id uuid
+    ) RETURNS TABLE (
+        player1_id uuid,
+        player2_id uuid,
+        player1_name text,
+        player2_name text,
+        player1_games_played integer,
+        player2_games_played integer,
+        player1_total_drinks numeric,
+        player2_total_drinks numeric,
+        player1_average_per_game numeric,
+        player2_average_per_game numeric,
+        games_played_together integer,
+        player1_wins_count integer,
+        player2_wins_count integer,
+        tied_games_count integer,
+        player1_max_in_a_game numeric,
+        player2_max_in_a_game numeric,
+        player1_common_match_count integer,
+        player2_common_match_count integer,
+        player1_efficiency numeric,
+        player2_efficiency numeric,
+        player1_top_drinker_count integer,
+        player2_top_drinker_count integer,
+        player1_avg_with_player2 numeric,
+        player1_avg_without_player2 numeric,
+        player2_avg_with_player1 numeric,
+        player2_avg_without_player1 numeric,
+        timeline_data jsonb
+    ) LANGUAGE plpgsql STABLE AS $$ BEGIN IF NOT EXISTS (
+        SELECT 1
+        FROM private._history_participant_session_rollups participants
+        WHERE participants.session_id = p_session_id
+            AND participants.participant_id = p_left_participant_id
+    )
+    OR NOT EXISTS (
+        SELECT 1
+        FROM private._history_participant_session_rollups participants
+        WHERE participants.session_id = p_session_id
+            AND participants.participant_id = p_right_participant_id
+    ) THEN RAISE EXCEPTION 'participants must belong to the same completed session %',
+    p_session_id;
+END IF;
+RETURN QUERY WITH left_games AS (
+    SELECT participants.session_id,
+        participants.completed_at,
+        participants.current_drink_total,
+        participants.common_match_id,
+        participants.session_match_count,
+        participants.is_top_drinker,
+        participants.display_name
+    FROM private._history_participant_session_rollups participants
+    WHERE participants.session_id = p_session_id
+        AND participants.participant_id = p_left_participant_id
+),
+right_games AS (
+    SELECT participants.session_id,
+        participants.completed_at,
+        participants.current_drink_total,
+        participants.common_match_id,
+        participants.session_match_count,
+        participants.is_top_drinker,
+        participants.display_name
+    FROM private._history_participant_session_rollups participants
+    WHERE participants.session_id = p_session_id
+        AND participants.participant_id = p_right_participant_id
+),
+shared_games AS (
+    SELECT left_games.session_id,
+        left_games.completed_at,
+        left_games.current_drink_total AS player1_drinks,
+        right_games.current_drink_total AS player2_drinks
+    FROM left_games
+        INNER JOIN right_games USING (session_id)
+),
+left_without_games AS (
+    SELECT left_games.*
+    FROM left_games
+        LEFT JOIN shared_games USING (session_id)
+    WHERE shared_games.session_id IS NULL
+),
+right_without_games AS (
+    SELECT right_games.*
+    FROM right_games
+        LEFT JOIN shared_games USING (session_id)
+    WHERE shared_games.session_id IS NULL
+),
+left_totals AS (
+    SELECT count(*)::integer AS games_played,
+        COALESCE(sum(current_drink_total), 0)::numeric AS total_drinks,
+        COALESCE(sum(session_match_count), 0)::integer AS total_matches,
+        COALESCE(max(current_drink_total), 0)::numeric AS max_in_a_game,
+        COALESCE(
+            count(*) FILTER (
+                WHERE common_match_id IS NOT NULL
+            ),
+            0
+        )::integer AS common_match_count,
+        COALESCE(
+            count(*) FILTER (
+                WHERE is_top_drinker
+            ),
+            0
+        )::integer AS top_drinker_count
+    FROM left_games
+),
+right_totals AS (
+    SELECT count(*)::integer AS games_played,
+        COALESCE(sum(current_drink_total), 0)::numeric AS total_drinks,
+        COALESCE(sum(session_match_count), 0)::integer AS total_matches,
+        COALESCE(max(current_drink_total), 0)::numeric AS max_in_a_game,
+        COALESCE(
+            count(*) FILTER (
+                WHERE common_match_id IS NOT NULL
+            ),
+            0
+        )::integer AS common_match_count,
+        COALESCE(
+            count(*) FILTER (
+                WHERE is_top_drinker
+            ),
+            0
+        )::integer AS top_drinker_count
+    FROM right_games
+)
+SELECT p_left_participant_id AS player1_id,
+    p_right_participant_id AS player2_id,
+    (
+        SELECT display_name
+        FROM left_games
+        LIMIT 1
+    ) AS player1_name,
+    (
+        SELECT display_name
+        FROM right_games
+        LIMIT 1
+    ) AS player2_name,
+    left_totals.games_played AS player1_games_played,
+    right_totals.games_played AS player2_games_played,
+    left_totals.total_drinks AS player1_total_drinks,
+    right_totals.total_drinks AS player2_total_drinks,
+    CASE
+        WHEN left_totals.games_played > 0 THEN left_totals.total_drinks / left_totals.games_played
+        ELSE 0
+    END AS player1_average_per_game,
+    CASE
+        WHEN right_totals.games_played > 0 THEN right_totals.total_drinks / right_totals.games_played
+        ELSE 0
+    END AS player2_average_per_game,
+    COALESCE(
+        (
+            SELECT count(*)::integer
+            FROM shared_games
+        ),
+        0
+    ) AS games_played_together,
+    COALESCE(
+        (
+            SELECT count(*)::integer
+            FROM shared_games
+            WHERE player1_drinks > player2_drinks
+        ),
+        0
+    ) AS player1_wins_count,
+    COALESCE(
+        (
+            SELECT count(*)::integer
+            FROM shared_games
+            WHERE player2_drinks > player1_drinks
+        ),
+        0
+    ) AS player2_wins_count,
+    COALESCE(
+        (
+            SELECT count(*)::integer
+            FROM shared_games
+            WHERE player1_drinks = player2_drinks
+        ),
+        0
+    ) AS tied_games_count,
+    left_totals.max_in_a_game AS player1_max_in_a_game,
+    right_totals.max_in_a_game AS player2_max_in_a_game,
+    left_totals.common_match_count AS player1_common_match_count,
+    right_totals.common_match_count AS player2_common_match_count,
+    CASE
+        WHEN left_totals.total_matches > 0 THEN left_totals.total_drinks / left_totals.total_matches
+        ELSE 0
+    END AS player1_efficiency,
+    CASE
+        WHEN right_totals.total_matches > 0 THEN right_totals.total_drinks / right_totals.total_matches
+        ELSE 0
+    END AS player2_efficiency,
+    left_totals.top_drinker_count AS player1_top_drinker_count,
+    right_totals.top_drinker_count AS player2_top_drinker_count,
+    COALESCE(
+        (
+            SELECT CASE
+                    WHEN count(*) > 0 THEN sum(player1_drinks) / count(*)
+                    ELSE 0
+                END
+            FROM shared_games
+        ),
+        0
+    ) AS player1_avg_with_player2,
+    COALESCE(
+        (
+            SELECT CASE
+                    WHEN count(*) > 0 THEN sum(current_drink_total) / count(*)
+                    ELSE 0
+                END
+            FROM left_without_games
+        ),
+        0
+    ) AS player1_avg_without_player2,
+    COALESCE(
+        (
+            SELECT CASE
+                    WHEN count(*) > 0 THEN sum(player2_drinks) / count(*)
+                    ELSE 0
+                END
+            FROM shared_games
+        ),
+        0
+    ) AS player2_avg_with_player1,
+    COALESCE(
+        (
+            SELECT CASE
+                    WHEN count(*) > 0 THEN sum(current_drink_total) / count(*)
+                    ELSE 0
+                END
+            FROM right_without_games
+        ),
+        0
+    ) AS player2_avg_without_player1,
+    COALESCE(
+        (
+            SELECT jsonb_agg(
+                    jsonb_build_object(
+                        'date',
+                        completed_at::text,
+                        'player1Drinks',
+                        player1_drinks,
+                        'player2Drinks',
+                        player2_drinks
+                    )
+                    ORDER BY completed_at,
+                        session_id
+                )
+            FROM shared_games
+        ),
+        '[]'::jsonb
+    ) AS timeline_data
+FROM left_totals,
+    right_totals;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.compare_session_participants(uuid, uuid, uuid)
+FROM PUBLIC,
+    anon,
+    authenticated;
+GRANT EXECUTE ON FUNCTION public.compare_session_participants(uuid, uuid, uuid) TO authenticated,
+    service_role;

--- a/supabase/migrations/022_history_read_models_leaderboard.sql
+++ b/supabase/migrations/022_history_read_models_leaderboard.sql
@@ -1,0 +1,23 @@
+-- 022_history_read_models_leaderboard.sql
+-- Ranked leaderboard built from lifetime stats.
+CREATE OR REPLACE VIEW public.leaderboard_entries WITH (security_invoker = true) AS
+SELECT row_number() OVER (
+        ORDER BY lifetime_stats.total_drinks DESC,
+            lifetime_stats.average_per_game DESC,
+            lifetime_stats.account_id ASC
+    )::integer AS rank,
+    lifetime_stats.account_id,
+    lifetime_stats.display_name,
+    lifetime_stats.total_drinks,
+    lifetime_stats.games_played,
+    lifetime_stats.average_per_game
+FROM public.lifetime_player_stats lifetime_stats
+ORDER BY lifetime_stats.total_drinks DESC,
+    lifetime_stats.average_per_game DESC,
+    lifetime_stats.account_id ASC;
+REVOKE ALL ON TABLE public.leaderboard_entries
+FROM PUBLIC,
+    anon,
+    authenticated;
+GRANT SELECT ON TABLE public.leaderboard_entries TO authenticated,
+    service_role;

--- a/supabase/tests/database/070_history_read_models_history.test.sql
+++ b/supabase/tests/database/070_history_read_models_history.test.sql
@@ -1,0 +1,378 @@
+BEGIN;
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+SELECT plan(18);
+INSERT INTO auth.users (
+        id,
+        aud,
+        role,
+        email,
+        email_confirmed_at,
+        created_at,
+        updated_at,
+        raw_app_meta_data,
+        raw_user_meta_data,
+        is_sso_user,
+        is_anonymous
+    )
+VALUES (
+        '10000000-0000-0000-0000-000000000001',
+        'authenticated',
+        'authenticated',
+        'history-host@test.local',
+        now(),
+        now(),
+        now(),
+        '{"provider":"email","providers":["email"]}'::jsonb,
+        '{}'::jsonb,
+        FALSE,
+        FALSE
+    ),
+    (
+        '10000000-0000-0000-0000-000000000002',
+        'authenticated',
+        'authenticated',
+        'history-friend@test.local',
+        now(),
+        now(),
+        now(),
+        '{"provider":"email","providers":["email"]}'::jsonb,
+        '{}'::jsonb,
+        FALSE,
+        FALSE
+    );
+INSERT INTO public.accounts (id, preferred_display_name)
+VALUES (
+        '10000000-0000-0000-0000-000000000001',
+        'History Host'
+    ),
+    (
+        '10000000-0000-0000-0000-000000000002',
+        'History Friend'
+    );
+INSERT INTO public.game_sessions (
+        id,
+        host_account_id,
+        join_code,
+        state,
+        started_at,
+        completed_at
+    )
+VALUES (
+        '20000000-0000-0000-0000-000000000001',
+        '10000000-0000-0000-0000-000000000001',
+        'HIST01',
+        'completed',
+        '2026-05-01 10:00:00+00',
+        '2026-05-01 12:00:00+00'
+    ),
+    (
+        '20000000-0000-0000-0000-000000000002',
+        '10000000-0000-0000-0000-000000000001',
+        'HIST02',
+        'completed',
+        '2026-05-02 10:00:00+00',
+        '2026-05-02 12:00:00+00'
+    );
+INSERT INTO public.participants (
+        id,
+        session_id,
+        account_id,
+        display_name,
+        membership_type,
+        current_drink_total,
+        guest_rejoin_token_hash
+    )
+VALUES (
+        '40000000-0000-0000-0000-000000000001',
+        '20000000-0000-0000-0000-000000000001',
+        '10000000-0000-0000-0000-000000000001',
+        'History Host',
+        'registered',
+        4.0,
+        NULL
+    ),
+    (
+        '40000000-0000-0000-0000-000000000002',
+        '20000000-0000-0000-0000-000000000001',
+        '10000000-0000-0000-0000-000000000002',
+        'History Friend',
+        'registered',
+        2.0,
+        NULL
+    ),
+    (
+        '40000000-0000-0000-0000-000000000003',
+        '20000000-0000-0000-0000-000000000002',
+        '10000000-0000-0000-0000-000000000001',
+        'History Host',
+        'registered',
+        5.0,
+        NULL
+    ),
+    (
+        '40000000-0000-0000-0000-000000000004',
+        '20000000-0000-0000-0000-000000000002',
+        '10000000-0000-0000-0000-000000000002',
+        'History Friend',
+        'registered',
+        1.0,
+        NULL
+    ),
+    (
+        '40000000-0000-0000-0000-000000000005',
+        '20000000-0000-0000-0000-000000000002',
+        NULL,
+        'History Guest',
+        'guest',
+        2.0,
+        'guest-history-token'
+    );
+INSERT INTO public.matches (
+        id,
+        session_id,
+        source_provider,
+        source_match_id,
+        home_team_name,
+        away_team_name,
+        kickoff_at,
+        home_score,
+        away_score
+    )
+VALUES (
+        '30000000-0000-0000-0000-000000000001',
+        '20000000-0000-0000-0000-000000000001',
+        'espn',
+        'hist-old-1',
+        'Old Home',
+        'Old Away',
+        '2026-05-01 10:15:00+00',
+        2,
+        1
+    ),
+    (
+        '30000000-0000-0000-0000-000000000002',
+        '20000000-0000-0000-0000-000000000002',
+        'espn',
+        'hist-new-1',
+        'New Home',
+        'New Away',
+        '2026-05-02 10:15:00+00',
+        1,
+        1
+    ),
+    (
+        '30000000-0000-0000-0000-000000000003',
+        '20000000-0000-0000-0000-000000000002',
+        'espn',
+        'hist-new-2',
+        'New Home 2',
+        'New Away 2',
+        '2026-05-02 11:15:00+00',
+        0,
+        2
+    );
+INSERT INTO public.assignments (session_id, participant_id, match_id)
+VALUES (
+        '20000000-0000-0000-0000-000000000001',
+        '40000000-0000-0000-0000-000000000001',
+        '30000000-0000-0000-0000-000000000001'
+    ),
+    (
+        '20000000-0000-0000-0000-000000000001',
+        '40000000-0000-0000-0000-000000000002',
+        '30000000-0000-0000-0000-000000000001'
+    ),
+    (
+        '20000000-0000-0000-0000-000000000002',
+        '40000000-0000-0000-0000-000000000003',
+        '30000000-0000-0000-0000-000000000002'
+    ),
+    (
+        '20000000-0000-0000-0000-000000000002',
+        '40000000-0000-0000-0000-000000000003',
+        '30000000-0000-0000-0000-000000000003'
+    ),
+    (
+        '20000000-0000-0000-0000-000000000002',
+        '40000000-0000-0000-0000-000000000004',
+        '30000000-0000-0000-0000-000000000002'
+    ),
+    (
+        '20000000-0000-0000-0000-000000000002',
+        '40000000-0000-0000-0000-000000000005',
+        '30000000-0000-0000-0000-000000000003'
+    );
+UPDATE public.game_sessions
+SET common_match_id = '30000000-0000-0000-0000-000000000001'
+WHERE id = '20000000-0000-0000-0000-000000000001';
+UPDATE public.game_sessions
+SET common_match_id = '30000000-0000-0000-0000-000000000002'
+WHERE id = '20000000-0000-0000-0000-000000000002';
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.role', 'authenticated', true);
+SELECT set_config(
+        'request.jwt.claim.sub',
+        '10000000-0000-0000-0000-000000000001',
+        true
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.completed_session_summaries
+        ),
+        '2',
+        'two completed sessions are exposed'
+    );
+SELECT is(
+        (
+            SELECT string_agg(
+                    session_id::text,
+                    ','
+                    ORDER BY completed_at DESC,
+                        session_id DESC
+                )
+            FROM public.completed_session_summaries
+        ),
+        '20000000-0000-0000-0000-000000000002,20000000-0000-0000-0000-000000000001',
+        'completed sessions are ordered newest first'
+    );
+SELECT is(
+        (
+            SELECT session_total_players::text
+            FROM public.completed_session_summaries
+            WHERE session_id = '20000000-0000-0000-0000-000000000002'
+        ),
+        '3',
+        'new session counts three players'
+    );
+SELECT is(
+        (
+            SELECT session_total_matches::text
+            FROM public.completed_session_summaries
+            WHERE session_id = '20000000-0000-0000-0000-000000000002'
+        ),
+        '2',
+        'new session counts two matches'
+    );
+SELECT is(
+        (
+            SELECT session_total_goals::text
+            FROM public.completed_session_summaries
+            WHERE session_id = '20000000-0000-0000-0000-000000000002'
+        ),
+        '4',
+        'new session totals the match goals'
+    );
+SELECT is(
+        (
+            SELECT session_total_drinks::text
+            FROM public.completed_session_summaries
+            WHERE session_id = '20000000-0000-0000-0000-000000000002'
+        ),
+        '8.0',
+        'new session totals the participant drinks'
+    );
+SELECT is(
+        (
+            SELECT jsonb_array_length(players)::text
+            FROM public.completed_session_summaries
+            WHERE session_id = '20000000-0000-0000-0000-000000000002'
+        ),
+        '3',
+        'new session exposes three players'
+    );
+SELECT is(
+        (
+            SELECT players->0->>'name'
+            FROM public.completed_session_summaries
+            WHERE session_id = '20000000-0000-0000-0000-000000000002'
+        ),
+        'History Host',
+        'player payload includes the host name'
+    );
+SELECT is(
+        (
+            SELECT jsonb_array_length(matches)::text
+            FROM public.completed_session_summaries
+            WHERE session_id = '20000000-0000-0000-0000-000000000002'
+        ),
+        '2',
+        'new session exposes two matches'
+    );
+SELECT ok(
+        (
+            SELECT player_assignments ? '40000000-0000-0000-0000-000000000003'
+            FROM public.completed_session_summaries
+            WHERE session_id = '20000000-0000-0000-0000-000000000002'
+        ),
+        'assignment payload includes the host participant'
+    );
+SELECT ok(
+        (
+            SELECT matches_per_player > 0
+            FROM public.completed_session_summaries
+            WHERE session_id = '20000000-0000-0000-0000-000000000002'
+        ),
+        'matches-per-player is computed'
+    );
+SELECT is(
+        (
+            SELECT session_total_players::text
+            FROM public.completed_session_summaries
+            WHERE session_id = '20000000-0000-0000-0000-000000000001'
+        ),
+        '2',
+        'old session counts two players'
+    );
+SELECT is(
+        (
+            SELECT total_sessions::text
+            FROM public.history_overview_totals
+        ),
+        '2',
+        'overview counts both completed sessions'
+    );
+SELECT is(
+        (
+            SELECT total_participations::text
+            FROM public.history_overview_totals
+        ),
+        '5',
+        'overview counts all participant rows'
+    );
+SELECT is(
+        (
+            SELECT total_matches::text
+            FROM public.history_overview_totals
+        ),
+        '3',
+        'overview counts all matches'
+    );
+SELECT is(
+        (
+            SELECT total_goals::text
+            FROM public.history_overview_totals
+        ),
+        '7',
+        'overview totals all goals'
+    );
+SELECT is(
+        (
+            SELECT total_drinks::text
+            FROM public.history_overview_totals
+        ),
+        '14.0',
+        'overview totals all drinks'
+    );
+SELECT is(
+        (
+            SELECT round(average_drinks_per_participation::numeric, 1)::text
+            FROM public.history_overview_totals
+        ),
+        '2.8',
+        'overview averages drinks per participation'
+    );
+SELECT *
+FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/080_history_read_models_lifetime.test.sql
+++ b/supabase/tests/database/080_history_read_models_lifetime.test.sql
@@ -1,0 +1,213 @@
+BEGIN;
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+SELECT plan(7);
+INSERT INTO auth.users (
+        id,
+        aud,
+        role,
+        email,
+        email_confirmed_at,
+        created_at,
+        updated_at,
+        raw_app_meta_data,
+        raw_user_meta_data,
+        is_sso_user,
+        is_anonymous
+    )
+VALUES (
+        '11000000-0000-0000-0000-000000000001',
+        'authenticated',
+        'authenticated',
+        'lifetime-host@test.local',
+        now(),
+        now(),
+        now(),
+        '{"provider":"email","providers":["email"]}'::jsonb,
+        '{}'::jsonb,
+        FALSE,
+        FALSE
+    ),
+    (
+        '11000000-0000-0000-0000-000000000002',
+        'authenticated',
+        'authenticated',
+        'lifetime-friend@test.local',
+        now(),
+        now(),
+        now(),
+        '{"provider":"email","providers":["email"]}'::jsonb,
+        '{}'::jsonb,
+        FALSE,
+        FALSE
+    ),
+    (
+        '11000000-0000-0000-0000-000000000003',
+        'authenticated',
+        'authenticated',
+        'lifetime-unused@test.local',
+        now(),
+        now(),
+        now(),
+        '{"provider":"email","providers":["email"]}'::jsonb,
+        '{}'::jsonb,
+        FALSE,
+        FALSE
+    );
+INSERT INTO public.accounts (id, preferred_display_name)
+VALUES (
+        '11000000-0000-0000-0000-000000000001',
+        'Lifetime Host'
+    ),
+    (
+        '11000000-0000-0000-0000-000000000002',
+        'Lifetime Friend'
+    ),
+    (
+        '11000000-0000-0000-0000-000000000003',
+        'Unused Player'
+    );
+INSERT INTO public.game_sessions (
+        id,
+        host_account_id,
+        join_code,
+        state,
+        started_at,
+        completed_at
+    )
+VALUES (
+        '21000000-0000-0000-0000-000000000001',
+        '11000000-0000-0000-0000-000000000001',
+        'LIFE01',
+        'completed',
+        '2026-05-01 08:00:00+00',
+        '2026-05-01 09:00:00+00'
+    ),
+    (
+        '21000000-0000-0000-0000-000000000002',
+        '11000000-0000-0000-0000-000000000001',
+        'LIFE02',
+        'completed',
+        '2026-05-02 08:00:00+00',
+        '2026-05-02 09:00:00+00'
+    );
+INSERT INTO public.participants (
+        id,
+        session_id,
+        account_id,
+        display_name,
+        membership_type,
+        current_drink_total,
+        guest_rejoin_token_hash
+    )
+VALUES (
+        '41000000-0000-0000-0000-000000000001',
+        '21000000-0000-0000-0000-000000000001',
+        '11000000-0000-0000-0000-000000000001',
+        'Lifetime Host',
+        'registered',
+        4.0,
+        NULL
+    ),
+    (
+        '41000000-0000-0000-0000-000000000002',
+        '21000000-0000-0000-0000-000000000001',
+        '11000000-0000-0000-0000-000000000002',
+        'Lifetime Friend',
+        'registered',
+        2.0,
+        NULL
+    ),
+    (
+        '41000000-0000-0000-0000-000000000003',
+        '21000000-0000-0000-0000-000000000002',
+        '11000000-0000-0000-0000-000000000001',
+        'Lifetime Host',
+        'registered',
+        5.0,
+        NULL
+    ),
+    (
+        '41000000-0000-0000-0000-000000000004',
+        '21000000-0000-0000-0000-000000000002',
+        NULL,
+        'Lifetime Guest',
+        'guest',
+        3.0,
+        'lifetime-guest-token'
+    );
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.role', 'authenticated', true);
+SELECT set_config(
+        'request.jwt.claim.sub',
+        '11000000-0000-0000-0000-000000000001',
+        true
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.lifetime_player_stats
+        ),
+        '2',
+        'only registered accounts with completed sessions are returned'
+    );
+SELECT is(
+        (
+            SELECT string_agg(
+                    account_id::text,
+                    ','
+                    ORDER BY total_drinks DESC,
+                        average_per_game DESC,
+                        account_id ASC
+                )
+            FROM public.lifetime_player_stats
+        ),
+        '11000000-0000-0000-0000-000000000001,11000000-0000-0000-0000-000000000002',
+        'lifetime stats are ordered by total drinks, average per game, then account id'
+    );
+SELECT is(
+        (
+            SELECT games_played::text
+            FROM public.lifetime_player_stats
+            WHERE account_id = '11000000-0000-0000-0000-000000000001'
+        ),
+        '2',
+        'host appears in two completed sessions'
+    );
+SELECT is(
+        (
+            SELECT total_drinks::text
+            FROM public.lifetime_player_stats
+            WHERE account_id = '11000000-0000-0000-0000-000000000001'
+        ),
+        '9.0',
+        'host lifetime total drinks are aggregated'
+    );
+SELECT is(
+        (
+            SELECT round(average_per_game::numeric, 1)::text
+            FROM public.lifetime_player_stats
+            WHERE account_id = '11000000-0000-0000-0000-000000000001'
+        ),
+        '4.5',
+        'host lifetime average per game is calculated'
+    );
+SELECT ok(
+        NOT EXISTS (
+            SELECT 1
+            FROM public.lifetime_player_stats
+            WHERE account_id = '11000000-0000-0000-0000-000000000003'
+        ),
+        'players with no completed sessions are excluded'
+    );
+SELECT ok(
+        NOT EXISTS (
+            SELECT 1
+            FROM public.lifetime_player_stats
+            WHERE display_name = 'Lifetime Guest'
+        ),
+        'guest participants are excluded from lifetime stats'
+    );
+SELECT *
+FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/090_history_read_models_comparisons.test.sql
+++ b/supabase/tests/database/090_history_read_models_comparisons.test.sql
@@ -1,0 +1,501 @@
+BEGIN;
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+SELECT plan(21);
+INSERT INTO auth.users (
+        id,
+        aud,
+        role,
+        email,
+        email_confirmed_at,
+        created_at,
+        updated_at,
+        raw_app_meta_data,
+        raw_user_meta_data,
+        is_sso_user,
+        is_anonymous
+    )
+VALUES (
+        '13000000-0000-0000-0000-000000000001',
+        'authenticated',
+        'authenticated',
+        'compare-alpha@test.local',
+        now(),
+        now(),
+        now(),
+        '{"provider":"email","providers":["email"]}'::jsonb,
+        '{}'::jsonb,
+        FALSE,
+        FALSE
+    ),
+    (
+        '13000000-0000-0000-0000-000000000002',
+        'authenticated',
+        'authenticated',
+        'compare-bravo@test.local',
+        now(),
+        now(),
+        now(),
+        '{"provider":"email","providers":["email"]}'::jsonb,
+        '{}'::jsonb,
+        FALSE,
+        FALSE
+    ),
+    (
+        '13000000-0000-0000-0000-000000000003',
+        'authenticated',
+        'authenticated',
+        'compare-charlie@test.local',
+        now(),
+        now(),
+        now(),
+        '{"provider":"email","providers":["email"]}'::jsonb,
+        '{}'::jsonb,
+        FALSE,
+        FALSE
+    );
+INSERT INTO public.accounts (id, preferred_display_name)
+VALUES (
+        '13000000-0000-0000-0000-000000000001',
+        'Compare Alpha'
+    ),
+    (
+        '13000000-0000-0000-0000-000000000002',
+        'Compare Bravo'
+    ),
+    (
+        '13000000-0000-0000-0000-000000000003',
+        'Compare Charlie'
+    );
+INSERT INTO public.game_sessions (
+        id,
+        host_account_id,
+        join_code,
+        state,
+        started_at,
+        completed_at,
+        common_match_id
+    )
+VALUES (
+        '23000000-0000-0000-0000-000000000001',
+        '13000000-0000-0000-0000-000000000001',
+        'CMP01',
+        'completed',
+        '2026-05-01 08:00:00+00',
+        '2026-05-01 09:00:00+00',
+        NULL
+    ),
+    (
+        '23000000-0000-0000-0000-000000000002',
+        '13000000-0000-0000-0000-000000000001',
+        'CMP02',
+        'completed',
+        '2026-05-02 08:00:00+00',
+        '2026-05-02 09:00:00+00',
+        NULL
+    ),
+    (
+        '23000000-0000-0000-0000-000000000003',
+        '13000000-0000-0000-0000-000000000001',
+        'CMP03',
+        'completed',
+        '2026-05-03 08:00:00+00',
+        '2026-05-03 09:00:00+00',
+        NULL
+    ),
+    (
+        '23000000-0000-0000-0000-000000000004',
+        '13000000-0000-0000-0000-000000000003',
+        'CMP04',
+        'completed',
+        '2026-05-04 08:00:00+00',
+        '2026-05-04 09:00:00+00',
+        NULL
+    );
+INSERT INTO public.matches (
+        id,
+        session_id,
+        source_provider,
+        source_match_id,
+        home_team_name,
+        away_team_name,
+        kickoff_at,
+        home_score,
+        away_score
+    )
+VALUES (
+        '33000000-0000-0000-0000-000000000001',
+        '23000000-0000-0000-0000-000000000001',
+        'espn',
+        'cmp-1',
+        'Home 1',
+        'Away 1',
+        '2026-05-01 08:30:00+00',
+        1,
+        0
+    ),
+    (
+        '33000000-0000-0000-0000-000000000002',
+        '23000000-0000-0000-0000-000000000002',
+        'espn',
+        'cmp-2',
+        'Home 2',
+        'Away 2',
+        '2026-05-02 08:30:00+00',
+        0,
+        1
+    ),
+    (
+        '33000000-0000-0000-0000-000000000003',
+        '23000000-0000-0000-0000-000000000003',
+        'espn',
+        'cmp-3',
+        'Home 3',
+        'Away 3',
+        '2026-05-03 08:30:00+00',
+        2,
+        1
+    ),
+    (
+        '33000000-0000-0000-0000-000000000004',
+        '23000000-0000-0000-0000-000000000004',
+        'espn',
+        'cmp-4',
+        'Home 4',
+        'Away 4',
+        '2026-05-04 08:30:00+00',
+        1,
+        1
+    );
+INSERT INTO public.participants (
+        id,
+        session_id,
+        account_id,
+        display_name,
+        membership_type,
+        current_drink_total,
+        guest_rejoin_token_hash
+    )
+VALUES (
+        '43000000-0000-0000-0000-000000000001',
+        '23000000-0000-0000-0000-000000000001',
+        '13000000-0000-0000-0000-000000000001',
+        'Compare Alpha',
+        'registered',
+        4.0,
+        NULL
+    ),
+    (
+        '43000000-0000-0000-0000-000000000002',
+        '23000000-0000-0000-0000-000000000001',
+        '13000000-0000-0000-0000-000000000002',
+        'Compare Bravo',
+        'registered',
+        2.0,
+        NULL
+    ),
+    (
+        '43000000-0000-0000-0000-000000000003',
+        '23000000-0000-0000-0000-000000000001',
+        NULL,
+        'Compare Guest',
+        'guest',
+        1.0,
+        'compare-guest-token'
+    ),
+    (
+        '43000000-0000-0000-0000-000000000004',
+        '23000000-0000-0000-0000-000000000002',
+        '13000000-0000-0000-0000-000000000001',
+        'Compare Alpha',
+        'registered',
+        1.0,
+        NULL
+    ),
+    (
+        '43000000-0000-0000-0000-000000000005',
+        '23000000-0000-0000-0000-000000000002',
+        '13000000-0000-0000-0000-000000000002',
+        'Compare Bravo',
+        'registered',
+        5.0,
+        NULL
+    ),
+    (
+        '43000000-0000-0000-0000-000000000006',
+        '23000000-0000-0000-0000-000000000003',
+        '13000000-0000-0000-0000-000000000001',
+        'Compare Alpha',
+        'registered',
+        7.0,
+        NULL
+    ),
+    (
+        '43000000-0000-0000-0000-000000000007',
+        '23000000-0000-0000-0000-000000000004',
+        '13000000-0000-0000-0000-000000000003',
+        'Compare Charlie',
+        'registered',
+        2.0,
+        NULL
+    );
+UPDATE public.game_sessions
+SET common_match_id = '33000000-0000-0000-0000-000000000001'
+WHERE id = '23000000-0000-0000-0000-000000000001';
+UPDATE public.game_sessions
+SET common_match_id = '33000000-0000-0000-0000-000000000002'
+WHERE id = '23000000-0000-0000-0000-000000000002';
+UPDATE public.game_sessions
+SET common_match_id = '33000000-0000-0000-0000-000000000003'
+WHERE id = '23000000-0000-0000-0000-000000000003';
+UPDATE public.game_sessions
+SET common_match_id = '33000000-0000-0000-0000-000000000004'
+WHERE id = '23000000-0000-0000-0000-000000000004';
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.role', 'authenticated', true);
+SELECT set_config(
+        'request.jwt.claim.sub',
+        '13000000-0000-0000-0000-000000000001',
+        true
+    );
+SELECT is(
+        (
+            SELECT (
+                    player1_name = 'Compare Alpha'
+                    AND player2_name = 'Compare Bravo'
+                )::text
+            FROM public.compare_registered_players(
+                    '13000000-0000-0000-0000-000000000001',
+                    '13000000-0000-0000-0000-000000000002'
+                )
+        ),
+        'true',
+        'registered comparison returns the selected player names'
+    );
+SELECT is(
+        (
+            SELECT games_played_together::text
+            FROM public.compare_registered_players(
+                    '13000000-0000-0000-0000-000000000001',
+                    '13000000-0000-0000-0000-000000000002'
+                )
+        ),
+        '2',
+        'registered comparison counts shared sessions'
+    );
+SELECT is(
+        (
+            SELECT player1_games_played::text
+            FROM public.compare_registered_players(
+                    '13000000-0000-0000-0000-000000000001',
+                    '13000000-0000-0000-0000-000000000002'
+                )
+        ),
+        '3',
+        'registered comparison counts player 1 sessions'
+    );
+SELECT is(
+        (
+            SELECT player2_games_played::text
+            FROM public.compare_registered_players(
+                    '13000000-0000-0000-0000-000000000001',
+                    '13000000-0000-0000-0000-000000000002'
+                )
+        ),
+        '2',
+        'registered comparison counts player 2 sessions'
+    );
+SELECT is(
+        (
+            SELECT player1_total_drinks::text
+            FROM public.compare_registered_players(
+                    '13000000-0000-0000-0000-000000000001',
+                    '13000000-0000-0000-0000-000000000002'
+                )
+        ),
+        '12.0',
+        'registered comparison aggregates player 1 drinks'
+    );
+SELECT is(
+        (
+            SELECT player2_total_drinks::text
+            FROM public.compare_registered_players(
+                    '13000000-0000-0000-0000-000000000001',
+                    '13000000-0000-0000-0000-000000000002'
+                )
+        ),
+        '7.0',
+        'registered comparison aggregates player 2 drinks'
+    );
+SELECT is(
+        (
+            SELECT player1_wins_count::text
+            FROM public.compare_registered_players(
+                    '13000000-0000-0000-0000-000000000001',
+                    '13000000-0000-0000-0000-000000000002'
+                )
+        ),
+        '1',
+        'registered comparison counts player 1 wins'
+    );
+SELECT is(
+        (
+            SELECT player2_wins_count::text
+            FROM public.compare_registered_players(
+                    '13000000-0000-0000-0000-000000000001',
+                    '13000000-0000-0000-0000-000000000002'
+                )
+        ),
+        '1',
+        'registered comparison counts player 2 wins'
+    );
+SELECT is(
+        (
+            SELECT jsonb_array_length(timeline_data)::text
+            FROM public.compare_registered_players(
+                    '13000000-0000-0000-0000-000000000001',
+                    '13000000-0000-0000-0000-000000000002'
+                )
+        ),
+        '2',
+        'registered comparison returns a two-point timeline'
+    );
+SELECT is(
+        (
+            SELECT round(player1_avg_with_player2::numeric, 1)::text
+            FROM public.compare_registered_players(
+                    '13000000-0000-0000-0000-000000000001',
+                    '13000000-0000-0000-0000-000000000002'
+                )
+        ),
+        '2.5',
+        'registered comparison averages player 1 drinks with player 2'
+    );
+SELECT is(
+        (
+            SELECT round(player1_avg_without_player2::numeric, 1)::text
+            FROM public.compare_registered_players(
+                    '13000000-0000-0000-0000-000000000001',
+                    '13000000-0000-0000-0000-000000000002'
+                )
+        ),
+        '7.0',
+        'registered comparison averages player 1 drinks without player 2'
+    );
+SELECT is(
+        (
+            SELECT round(player2_avg_without_player1::numeric, 1)::text
+            FROM public.compare_registered_players(
+                    '13000000-0000-0000-0000-000000000001',
+                    '13000000-0000-0000-0000-000000000002'
+                )
+        ),
+        '0.0',
+        'registered comparison zeroes player 2 without-player-1 average when no sessions remain'
+    );
+SELECT is(
+        (
+            SELECT games_played_together::text
+            FROM public.compare_registered_players(
+                    '13000000-0000-0000-0000-000000000001',
+                    '13000000-0000-0000-0000-000000000003'
+                )
+        ),
+        '0',
+        'no-overlap registered comparison reports zero shared sessions'
+    );
+SELECT is(
+        (
+            SELECT jsonb_array_length(timeline_data)::text
+            FROM public.compare_registered_players(
+                    '13000000-0000-0000-0000-000000000001',
+                    '13000000-0000-0000-0000-000000000003'
+                )
+        ),
+        '0',
+        'no-overlap registered comparison returns an empty timeline'
+    );
+SELECT is(
+        (
+            SELECT round(player1_avg_with_player2::numeric, 1)::text
+            FROM public.compare_registered_players(
+                    '13000000-0000-0000-0000-000000000001',
+                    '13000000-0000-0000-0000-000000000003'
+                )
+        ),
+        '0.0',
+        'no-overlap registered comparison zeroes player 1 with-player-2 average'
+    );
+SELECT is(
+        (
+            SELECT round(player1_avg_without_player2::numeric, 1)::text
+            FROM public.compare_registered_players(
+                    '13000000-0000-0000-0000-000000000001',
+                    '13000000-0000-0000-0000-000000000003'
+                )
+        ),
+        '4.0',
+        'no-overlap registered comparison keeps player 1 without-player-2 average'
+    );
+SELECT is(
+        (
+            SELECT round(player2_avg_without_player1::numeric, 1)::text
+            FROM public.compare_registered_players(
+                    '13000000-0000-0000-0000-000000000001',
+                    '13000000-0000-0000-0000-000000000003'
+                )
+        ),
+        '2.0',
+        'no-overlap registered comparison keeps player 2 without-player-1 average'
+    );
+SELECT is(
+        (
+            SELECT player1_name
+            FROM public.compare_session_participants(
+                    '23000000-0000-0000-0000-000000000001',
+                    '43000000-0000-0000-0000-000000000003',
+                    '43000000-0000-0000-0000-000000000001'
+                )
+        ),
+        'Compare Guest',
+        'guest comparison uses the guest participant name'
+    );
+SELECT is(
+        (
+            SELECT player2_name
+            FROM public.compare_session_participants(
+                    '23000000-0000-0000-0000-000000000001',
+                    '43000000-0000-0000-0000-000000000003',
+                    '43000000-0000-0000-0000-000000000001'
+                )
+        ),
+        'Compare Alpha',
+        'guest comparison uses the registered participant name'
+    );
+SELECT is(
+        (
+            SELECT games_played_together::text
+            FROM public.compare_session_participants(
+                    '23000000-0000-0000-0000-000000000001',
+                    '43000000-0000-0000-0000-000000000003',
+                    '43000000-0000-0000-0000-000000000001'
+                )
+        ),
+        '1',
+        'guest comparison is scoped to the shared completed session'
+    );
+SELECT is(
+        (
+            SELECT jsonb_array_length(timeline_data)::text
+            FROM public.compare_session_participants(
+                    '23000000-0000-0000-0000-000000000001',
+                    '43000000-0000-0000-0000-000000000003',
+                    '43000000-0000-0000-0000-000000000001'
+                )
+        ),
+        '1',
+        'guest comparison returns a single timeline point'
+    );
+SELECT *
+FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/100_history_read_models_leaderboard.test.sql
+++ b/supabase/tests/database/100_history_read_models_leaderboard.test.sql
@@ -1,0 +1,245 @@
+BEGIN;
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+SELECT plan(7);
+INSERT INTO auth.users (
+        id,
+        aud,
+        role,
+        email,
+        email_confirmed_at,
+        created_at,
+        updated_at,
+        raw_app_meta_data,
+        raw_user_meta_data,
+        is_sso_user,
+        is_anonymous
+    )
+VALUES (
+        '12000000-0000-0000-0000-000000000001',
+        'authenticated',
+        'authenticated',
+        'leaderboard-a@test.local',
+        now(),
+        now(),
+        now(),
+        '{"provider":"email","providers":["email"]}'::jsonb,
+        '{}'::jsonb,
+        FALSE,
+        FALSE
+    ),
+    (
+        '12000000-0000-0000-0000-000000000002',
+        'authenticated',
+        'authenticated',
+        'leaderboard-b@test.local',
+        now(),
+        now(),
+        now(),
+        '{"provider":"email","providers":["email"]}'::jsonb,
+        '{}'::jsonb,
+        FALSE,
+        FALSE
+    ),
+    (
+        '12000000-0000-0000-0000-000000000003',
+        'authenticated',
+        'authenticated',
+        'leaderboard-c@test.local',
+        now(),
+        now(),
+        now(),
+        '{"provider":"email","providers":["email"]}'::jsonb,
+        '{}'::jsonb,
+        FALSE,
+        FALSE
+    ),
+    (
+        '12000000-0000-0000-0000-000000000004',
+        'authenticated',
+        'authenticated',
+        'leaderboard-unused@test.local',
+        now(),
+        now(),
+        now(),
+        '{"provider":"email","providers":["email"]}'::jsonb,
+        '{}'::jsonb,
+        FALSE,
+        FALSE
+    );
+INSERT INTO public.accounts (id, preferred_display_name)
+VALUES (
+        '12000000-0000-0000-0000-000000000001',
+        'Alpha'
+    ),
+    (
+        '12000000-0000-0000-0000-000000000002',
+        'Bravo'
+    ),
+    (
+        '12000000-0000-0000-0000-000000000003',
+        'Charlie'
+    ),
+    (
+        '12000000-0000-0000-0000-000000000004',
+        'Unused'
+    );
+INSERT INTO public.game_sessions (
+        id,
+        host_account_id,
+        join_code,
+        state,
+        started_at,
+        completed_at
+    )
+VALUES (
+        '22000000-0000-0000-0000-000000000001',
+        '12000000-0000-0000-0000-000000000001',
+        'LB01',
+        'completed',
+        '2026-05-01 08:00:00+00',
+        '2026-05-01 09:00:00+00'
+    ),
+    (
+        '22000000-0000-0000-0000-000000000002',
+        '12000000-0000-0000-0000-000000000001',
+        'LB02',
+        'completed',
+        '2026-05-02 08:00:00+00',
+        '2026-05-02 09:00:00+00'
+    ),
+    (
+        '22000000-0000-0000-0000-000000000003',
+        '12000000-0000-0000-0000-000000000001',
+        'LB03',
+        'completed',
+        '2026-05-03 08:00:00+00',
+        '2026-05-03 09:00:00+00'
+    );
+INSERT INTO public.participants (
+        id,
+        session_id,
+        account_id,
+        display_name,
+        membership_type,
+        current_drink_total,
+        guest_rejoin_token_hash
+    )
+VALUES (
+        '42000000-0000-0000-0000-000000000001',
+        '22000000-0000-0000-0000-000000000001',
+        '12000000-0000-0000-0000-000000000001',
+        'Alpha',
+        'registered',
+        4.0,
+        NULL
+    ),
+    (
+        '42000000-0000-0000-0000-000000000002',
+        '22000000-0000-0000-0000-000000000001',
+        '12000000-0000-0000-0000-000000000002',
+        'Bravo',
+        'registered',
+        6.0,
+        NULL
+    ),
+    (
+        '42000000-0000-0000-0000-000000000003',
+        '22000000-0000-0000-0000-000000000001',
+        NULL,
+        'Guest Alpha',
+        'guest',
+        1.0,
+        'leaderboard-guest-1'
+    ),
+    (
+        '42000000-0000-0000-0000-000000000004',
+        '22000000-0000-0000-0000-000000000002',
+        '12000000-0000-0000-0000-000000000001',
+        'Alpha',
+        'registered',
+        2.0,
+        NULL
+    ),
+    (
+        '42000000-0000-0000-0000-000000000005',
+        '22000000-0000-0000-0000-000000000003',
+        '12000000-0000-0000-0000-000000000003',
+        'Charlie',
+        'registered',
+        2.0,
+        NULL
+    );
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.role', 'authenticated', true);
+SELECT set_config(
+        'request.jwt.claim.sub',
+        '12000000-0000-0000-0000-000000000001',
+        true
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.leaderboard_entries
+        ),
+        '3',
+        'only registered accounts with completed sessions are ranked'
+    );
+SELECT is(
+        (
+            SELECT string_agg(
+                    account_id::text,
+                    ','
+                    ORDER BY rank
+                )
+            FROM public.leaderboard_entries
+        ),
+        '12000000-0000-0000-0000-000000000002,12000000-0000-0000-0000-000000000001,12000000-0000-0000-0000-000000000003',
+        'leaderboard is ordered by total drinks, average per game, then account id'
+    );
+SELECT is(
+        (
+            SELECT rank::text
+            FROM public.leaderboard_entries
+            WHERE account_id = '12000000-0000-0000-0000-000000000002'
+        ),
+        '1',
+        'highest total and average ranks first'
+    );
+SELECT is(
+        (
+            SELECT rank::text
+            FROM public.leaderboard_entries
+            WHERE account_id = '12000000-0000-0000-0000-000000000001'
+        ),
+        '2',
+        'second rank follows by the same totals with a lower average'
+    );
+SELECT is(
+        (
+            SELECT rank::text
+            FROM public.leaderboard_entries
+            WHERE account_id = '12000000-0000-0000-0000-000000000003'
+        ),
+        '3',
+        'third rank is assigned to the lower total'
+    );
+SELECT ok(
+        NOT EXISTS (
+            SELECT 1
+            FROM public.leaderboard_entries
+            WHERE account_id = '12000000-0000-0000-0000-000000000004'
+        ),
+        'users with no completed sessions are excluded from the leaderboard'
+    );
+SELECT ok(
+        NOT EXISTS (
+            SELECT 1
+            FROM public.leaderboard_entries
+            WHERE display_name = 'Guest Alpha'
+        ),
+        'guest participants are excluded from the leaderboard'
+    );
+SELECT *
+FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/110_history_read_models_performance.test.sql
+++ b/supabase/tests/database/110_history_read_models_performance.test.sql
@@ -1,0 +1,278 @@
+BEGIN;
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+SELECT plan(5);
+INSERT INTO auth.users (
+        id,
+        aud,
+        role,
+        email,
+        email_confirmed_at,
+        created_at,
+        updated_at,
+        raw_app_meta_data,
+        raw_user_meta_data,
+        is_sso_user,
+        is_anonymous
+    )
+VALUES (
+        '14000000-0000-0000-0000-000000000001',
+        'authenticated',
+        'authenticated',
+        'perf-alpha@test.local',
+        now(),
+        now(),
+        now(),
+        '{"provider":"email","providers":["email"]}'::jsonb,
+        '{}'::jsonb,
+        FALSE,
+        FALSE
+    ),
+    (
+        '14000000-0000-0000-0000-000000000002',
+        'authenticated',
+        'authenticated',
+        'perf-bravo@test.local',
+        now(),
+        now(),
+        now(),
+        '{"provider":"email","providers":["email"]}'::jsonb,
+        '{}'::jsonb,
+        FALSE,
+        FALSE
+    );
+INSERT INTO public.accounts (id, preferred_display_name)
+VALUES (
+        '14000000-0000-0000-0000-000000000001',
+        'Perf Alpha'
+    ),
+    (
+        '14000000-0000-0000-0000-000000000002',
+        'Perf Bravo'
+    );
+INSERT INTO public.game_sessions (
+        id,
+        host_account_id,
+        join_code,
+        state,
+        started_at,
+        completed_at,
+        common_match_id
+    )
+VALUES (
+        '24000000-0000-0000-0000-000000000001',
+        '14000000-0000-0000-0000-000000000001',
+        'PERF1',
+        'completed',
+        '2026-05-01 08:00:00+00',
+        '2026-05-01 09:00:00+00',
+        NULL
+    ),
+    (
+        '24000000-0000-0000-0000-000000000002',
+        '14000000-0000-0000-0000-000000000001',
+        'PERF2',
+        'completed',
+        '2026-05-02 08:00:00+00',
+        '2026-05-02 09:00:00+00',
+        NULL
+    );
+INSERT INTO public.matches (
+        id,
+        session_id,
+        source_provider,
+        source_match_id,
+        home_team_name,
+        away_team_name,
+        kickoff_at,
+        home_score,
+        away_score
+    )
+VALUES (
+        '34000000-0000-0000-0000-000000000001',
+        '24000000-0000-0000-0000-000000000001',
+        'espn',
+        'perf-1',
+        'Perf Home 1',
+        'Perf Away 1',
+        '2026-05-01 08:30:00+00',
+        1,
+        0
+    ),
+    (
+        '34000000-0000-0000-0000-000000000002',
+        '24000000-0000-0000-0000-000000000002',
+        'espn',
+        'perf-2',
+        'Perf Home 2',
+        'Perf Away 2',
+        '2026-05-02 08:30:00+00',
+        0,
+        1
+    );
+INSERT INTO public.participants (
+        id,
+        session_id,
+        account_id,
+        display_name,
+        membership_type,
+        current_drink_total,
+        guest_rejoin_token_hash
+    )
+VALUES (
+        '44000000-0000-0000-0000-000000000001',
+        '24000000-0000-0000-0000-000000000001',
+        '14000000-0000-0000-0000-000000000001',
+        'Perf Alpha',
+        'registered',
+        5.0,
+        NULL
+    ),
+    (
+        '44000000-0000-0000-0000-000000000002',
+        '24000000-0000-0000-0000-000000000001',
+        '14000000-0000-0000-0000-000000000002',
+        'Perf Bravo',
+        'registered',
+        1.0,
+        NULL
+    ),
+    (
+        '44000000-0000-0000-0000-000000000003',
+        '24000000-0000-0000-0000-000000000002',
+        '14000000-0000-0000-0000-000000000001',
+        'Perf Alpha',
+        'registered',
+        3.0,
+        NULL
+    );
+UPDATE public.game_sessions
+SET common_match_id = '34000000-0000-0000-0000-000000000001'
+WHERE id = '24000000-0000-0000-0000-000000000001';
+UPDATE public.game_sessions
+SET common_match_id = '34000000-0000-0000-0000-000000000002'
+WHERE id = '24000000-0000-0000-0000-000000000002';
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.role', 'authenticated', true);
+SELECT set_config(
+        'request.jwt.claim.sub',
+        '14000000-0000-0000-0000-000000000001',
+        true
+    );
+SET LOCAL enable_seqscan = off;
+CREATE TEMP TABLE performance_plans (
+    label text NOT NULL,
+    plan_text text NOT NULL
+);
+DO $do$
+DECLARE plan_line text;
+BEGIN FOR plan_line IN EXECUTE $sql$EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
+SELECT *
+FROM public.completed_session_summaries
+WHERE session_id = '24000000-0000-0000-0000-000000000001' $sql$ LOOP
+INSERT INTO performance_plans (label, plan_text)
+VALUES ('history', plan_line);
+END LOOP;
+END;
+$do$;
+DO $do$
+DECLARE plan_line text;
+BEGIN FOR plan_line IN EXECUTE $sql$EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
+SELECT *
+FROM public.lifetime_player_stats
+WHERE account_id = '14000000-0000-0000-0000-000000000001' $sql$ LOOP
+INSERT INTO performance_plans (label, plan_text)
+VALUES ('lifetime', plan_line);
+END LOOP;
+END;
+$do$;
+DO $do$
+DECLARE plan_line text;
+BEGIN FOR plan_line IN EXECUTE $sql$EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
+SELECT *
+FROM public.leaderboard_entries
+WHERE account_id = '14000000-0000-0000-0000-000000000001' $sql$ LOOP
+INSERT INTO performance_plans (label, plan_text)
+VALUES ('leaderboard', plan_line);
+END LOOP;
+END;
+$do$;
+CREATE TEMP TABLE performance_timings (
+    label text PRIMARY KEY,
+    elapsed interval NOT NULL
+);
+DO $do$
+DECLARE started_at timestamptz;
+finished_at timestamptz;
+BEGIN started_at := clock_timestamp();
+PERFORM 1
+FROM public.compare_registered_players(
+        '14000000-0000-0000-0000-000000000001',
+        '14000000-0000-0000-0000-000000000002'
+    );
+finished_at := clock_timestamp();
+INSERT INTO performance_timings (label, elapsed)
+VALUES ('registered', finished_at - started_at);
+END;
+$do$;
+DO $do$
+DECLARE started_at timestamptz;
+finished_at timestamptz;
+BEGIN started_at := clock_timestamp();
+PERFORM 1
+FROM public.compare_session_participants(
+        '24000000-0000-0000-0000-000000000001',
+        '44000000-0000-0000-0000-000000000001',
+        '44000000-0000-0000-0000-000000000002'
+    );
+finished_at := clock_timestamp();
+INSERT INTO performance_timings (label, elapsed)
+VALUES ('guest', finished_at - started_at);
+END;
+$do$;
+SELECT ok(
+        EXISTS (
+            SELECT 1
+            FROM performance_plans
+            WHERE label = 'history'
+                AND plan_text LIKE '%Index%'
+        ),
+        'completed-session history query uses an index-backed plan'
+    );
+SELECT ok(
+        EXISTS (
+            SELECT 1
+            FROM performance_plans
+            WHERE label = 'lifetime'
+                AND plan_text LIKE '%Index%'
+        ),
+        'lifetime stats query uses an index-backed plan'
+    );
+SELECT ok(
+        EXISTS (
+            SELECT 1
+            FROM performance_plans
+            WHERE label = 'leaderboard'
+                AND plan_text LIKE '%Index%'
+        ),
+        'leaderboard query uses an index-backed plan'
+    );
+SELECT ok(
+        (
+            SELECT elapsed < interval '250 milliseconds'
+            FROM performance_timings
+            WHERE label = 'registered'
+        ),
+        'registered comparison finishes within the smoke threshold'
+    );
+SELECT ok(
+        (
+            SELECT elapsed < interval '250 milliseconds'
+            FROM performance_timings
+            WHERE label = 'guest'
+        ),
+        'guest comparison finishes within the smoke threshold'
+    );
+SELECT *
+FROM finish();
+ROLLBACK;


### PR DESCRIPTION
- Implemented tests for lifetime player statistics, ensuring only registered accounts with completed sessions are returned and correctly aggregated.
- Added comparison tests for registered players, validating shared session counts, total drinks, and win counts.
- Created leaderboard tests to verify ranking logic based on total drinks and average per game, excluding users without completed sessions.
- Introduced performance tests to analyze query execution plans and timings for key functions, ensuring they utilize indexes and meet performance thresholds.

closes #126 