### PR TITLE
NOJIRA: Add one-time local-to-cloud import for existing registered users

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,6 +21,8 @@ Auto-generated from all feature plans. Last updated: 2026-05-09
 - New `supabase/` workspace in the repo, with additional `public` schema tables for profiles, settings, and friendships, and RLS enabled on those tables plus the existing room tables (151-add-data-rls)
 - TypeScript 5.3.3 in an Expo SDK 52 / React Native 0.76.9 workspace, plus SQL migrations and pgTAP tests executed against local Supabase Postgres + Supabase CLI, Supabase Auth/Postgres local stack, pgTAP database tests, existing Expo Router 4 workspace, Supabase `rpc()` support for SQL functions (126-us23-create-read-models-for-history-comparisons-and-leaderboards)
 - Existing `supabase/` workspace with new read-model views/functions and supporting tests; no new business tables are introduced in this feature (126-us23-create-read-models-for-history-comparisons-and-leaderboards)
+- TypeScript 5.3.3 in Expo SDK 52 / React Native 0.76.9 / React 18.3.1 + Expo Router 4, Zustand 5, AsyncStorage, `react-native-toast-message`, `@supabase/supabase-js`, Supabase Auth/Postgres local stack, Supabase CLI, pgTAP, `playwright-bdd`, `@playwright/test` (127-us24-add-one-time-local-to-cloud-import-for-existing-registered-users)
+- Existing AsyncStorage history snapshot plus new private Supabase import ledger tables; imported sessions land in current `public.game_sessions`, `participants`, `matches`, `assignments`, and `gameplay_events` (127-us24-add-one-time-local-to-cloud-import-for-existing-registered-users)
 
 - TypeScript 5.3.3 in an Expo SDK 52 / React Native 0.76.9 workspace + Expo Router 4, React 18.3.1, Zustand 5, AsyncStorage, `expo-av`, `react-native-date-picker`, `react-native-ui-datepicker`, `lottie-react-native`, `react-native-gesture-handler`, `react-native-reanimated`, Jest-Expo 52 (111-add-platform-abstractions)
 - Existing Zustand + AsyncStorage persistence remains unchanged; no new storage for this feature (111-add-platform-abstractions)
@@ -43,9 +45,9 @@ npm test; npm run lint
 Markdown documentation artifact inside a TypeScript 5.3.3 / Expo SDK 52 workspace: Follow standard conventions
 
 ## Recent Changes
+- 127-us24-add-one-time-local-to-cloud-import-for-existing-registered-users: Added TypeScript 5.3.3 in Expo SDK 52 / React Native 0.76.9 / React 18.3.1 + Expo Router 4, Zustand 5, AsyncStorage, `react-native-toast-message`, `@supabase/supabase-js`, Supabase Auth/Postgres local stack, Supabase CLI, pgTAP, `playwright-bdd`, `@playwright/test`
 - 126-us23-create-read-models-for-history-comparisons-and-leaderboards: Added TypeScript 5.3.3 in an Expo SDK 52 / React Native 0.76.9 workspace, plus SQL migrations and pgTAP tests executed against local Supabase Postgres + Supabase CLI, Supabase Auth/Postgres local stack, pgTAP database tests, existing Expo Router 4 workspace, Supabase `rpc()` support for SQL functions
 - 151-add-data-rls: Added TypeScript 5.3.3 in an Expo SDK 52 / React Native 0.76.9 workspace, plus SQL migrations executed through Supabase CLI against local Supabase Postgres + Supabase CLI, Supabase Auth/Postgres local stack, pgTAP database tests, existing Expo Router 4 workspace, existing Supabase `public.accounts` anchor from US2.1
-- 128-us21-create-the-core-supabase-schema-for-accounts-sessions-participants-matches-assignments-and-events: Added TypeScript 5.3.3 Expo workspace plus SQL migrations executed via Supabase CLI against local Supabase Postgres + Supabase CLI, Supabase Auth/Postgres local stack, pgTAP database tests, `basejump-supabase_test_helpers` for authenticated DB test contexts, existing Expo SDK 52 / React Native 0.76.9 workspace
 
 
 

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/009-history-read-models"
+  "feature_directory": "specs/010-local-cloud-import"
 }

--- a/__tests__/app/userPreferences.platform.test.tsx
+++ b/__tests__/app/userPreferences.platform.test.tsx
@@ -128,6 +128,20 @@ jest.mock("../../components/ui", () => ({
 jest.mock("../../components/OnboardingScreen", () => () => null);
 
 jest.mock("../../components/preferences/AddLeagueModal", () => () => null);
+jest.mock(
+  "../../components/preferences/LegacyHistoryImportSection",
+  () => () => {
+    const RN = require("react-native");
+    const R = require("react");
+
+    return R.createElement(
+      RN.View,
+      { testID: "LegacyHistoryImportSection" },
+      R.createElement(RN.Text, null, "History Import"),
+      R.createElement(RN.Text, null, "Import Local History"),
+    );
+  },
+);
 jest.mock("../../components/preferences/ManageLeaguesModal", () => () => null);
 jest.mock(
   "../../components/preferences/SelectDefaultLeaguesModal",
@@ -145,7 +159,7 @@ describe("UserPreferences shell adoption", () => {
     });
   });
 
-  it("renders Header, AppearanceSettings, SoundNotificationSettings, LeagueSettings, and OnboardingButton", () => {
+  it("renders Header, AppearanceSettings, SoundNotificationSettings, LeagueSettings, LegacyHistoryImportSection, and OnboardingButton", () => {
     const Screen = require("../../app/userPreferences").default;
 
     const renderer = TestRenderer.create(React.createElement(Screen));
@@ -158,6 +172,7 @@ describe("UserPreferences shell adoption", () => {
     expect(textContents).toContain("Appearance");
     expect(textContents).toContain("Sound & Notifications");
     expect(textContents).toContain("League Configuration");
+    expect(textContents).toContain("History Import");
     expect(textContents).toContain("View Onboarding");
 
     renderer.unmount();

--- a/__tests__/components/history/HistoryHeader.platform.test.tsx
+++ b/__tests__/components/history/HistoryHeader.platform.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import { TouchableOpacity, View } from "react-native";
 
 const mockUseWindowDimensions = jest.fn(() => ({
   width: 390,
@@ -110,7 +109,10 @@ describe("HistoryHeader responsive layout", () => {
       testID: "HistoryHeaderPlaceholder",
     });
 
-    expect(container.props.style).toEqual([{}, { testStyle: "pageHeaderWide" }]);
+    expect(container.props.style).toEqual([
+      {},
+      { testStyle: "pageHeaderWide" },
+    ]);
     expect(placeholder.props.style).toEqual({ testStyle: "rightPlaceholder" });
   });
 });

--- a/__tests__/components/preferences/LegacyHistoryImport.platform.test.tsx
+++ b/__tests__/components/preferences/LegacyHistoryImport.platform.test.tsx
@@ -1,0 +1,466 @@
+import React from "react";
+import TestRenderer from "react-test-renderer";
+
+const mockUseLegacyHistoryImport = jest.fn();
+
+jest.mock("react-native", () => {
+  const ReactNative = jest.requireActual("react-native");
+  const React = jest.requireActual("react");
+
+  return new Proxy(ReactNative, {
+    get(target, prop, receiver) {
+      if (prop === "Modal") {
+        const MockModal = ({ visible, children }: any) => {
+          if (!visible) {
+            return null;
+          }
+
+          return React.createElement(ReactNative.View, null, children);
+        };
+
+        MockModal.displayName = "MockModal";
+
+        return MockModal;
+      }
+
+      if (prop === "FlatList") {
+        const MockFlatList = ({ data, renderItem, keyExtractor }: any) =>
+          React.createElement(
+            ReactNative.View,
+            null,
+            data.map((item: any, index: number) =>
+              React.createElement(
+                React.Fragment,
+                {
+                  key: keyExtractor ? keyExtractor(item, index) : `${index}`,
+                },
+                renderItem({ item, index }),
+              ),
+            ),
+          );
+
+        MockFlatList.displayName = "MockFlatList";
+
+        return MockFlatList;
+      }
+
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+});
+
+jest.mock("../../../app/style/theme", () => ({
+  useColors: () => ({
+    primary: "#007AFF",
+    secondary: "#6C757D",
+    success: "#34C759",
+    warning: "#FF9500",
+    danger: "#FF3B30",
+    textPrimary: "#111111",
+    textSecondary: "#555555",
+    textLight: "#FFFFFF",
+    textMuted: "#888888",
+    surface: "#FFFFFF",
+    background: "#F5F5F5",
+    backgroundSubtle: "#EFEFEF",
+    borderSubtle: "#DDDDDD",
+  }),
+}));
+
+jest.mock("../../../app/style/userPreferencesStyles", () => ({
+  createUserPreferencesStyles: () => ({
+    legacyHistoryImportStyles: {
+      description: {},
+      summaryRow: {},
+      summaryLabel: {},
+      summaryValue: {},
+      statusPanel: {},
+      statusText: {},
+      statusTextSuccess: {},
+      statusTextError: {},
+      warningText: {},
+      resultSummaryRow: {},
+      resultSummaryLabel: {},
+      resultSummaryValue: {},
+      buttonContainer: {},
+      modalSafeArea: {},
+      modalHeader: {},
+      modalHeaderTitle: {},
+      modalCloseButton: {},
+      modalContent: {},
+      modalDescription: {},
+      claimantOptionRow: {},
+      claimantOptionRowDisabled: {},
+      claimantOptionContent: {},
+      claimantOptionName: {},
+      claimantOptionMeta: {},
+      claimantOptionWarning: {},
+      modalEmptyState: {},
+      modalEmptyTitle: {},
+      modalEmptyMessage: {},
+    },
+  }),
+}));
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock("../../../hooks/useLegacyHistoryImport", () => ({
+  useLegacyHistoryImport: () => mockUseLegacyHistoryImport(),
+}));
+
+jest.mock("../../../components/ui", () => ({
+  ShellSection: ({ children, title, ...props }: any) => {
+    const RN = require("react-native");
+    const R = require("react");
+
+    return R.createElement(
+      RN.View,
+      { testID: "ShellSection", ...props },
+      title ? R.createElement(RN.Text, null, title) : null,
+      children,
+    );
+  },
+  ShellCard: ({ children, ...props }: any) => {
+    const RN = require("react-native");
+    const R = require("react");
+
+    return R.createElement(
+      RN.View,
+      { testID: "ShellCard", ...props },
+      children,
+    );
+  },
+  ShellActionButton: ({ label, onPress, disabled, testID, ...props }: any) => {
+    const RN = require("react-native");
+    const R = require("react");
+
+    return R.createElement(
+      RN.TouchableOpacity,
+      { onPress, disabled, testID, ...props },
+      label ? R.createElement(RN.Text, null, label) : null,
+    );
+  },
+}));
+
+describe("LegacyHistoryImport Settings UI", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the empty-history state and keeps the action disabled", () => {
+    mockUseLegacyHistoryImport.mockReturnValue({
+      claimantOptions: [],
+      historySessionCount: 0,
+      hasLocalHistory: false,
+      isConfigured: true,
+      isAuthenticated: true,
+      authChecked: true,
+      isImporting: false,
+      importPhase: "ready",
+      canStartImport: false,
+      canRetryImport: false,
+      availabilityReason: "No local history saved on this device yet.",
+      importError: null,
+      importResult: null,
+      importHistory: jest.fn(),
+    });
+
+    const LegacyHistoryImportSection =
+      require("../../../components/preferences/LegacyHistoryImportSection").default;
+
+    const renderer = TestRenderer.create(
+      React.createElement(LegacyHistoryImportSection),
+    );
+
+    const { Text } = require("react-native");
+    const textContents = renderer.root
+      .findAllByType(Text)
+      .flatMap((node: any) => node.props.children);
+    const action = renderer.root.findByProps({
+      testID: "LegacyHistoryImportButton",
+    });
+
+    expect(textContents).toContain("History Import");
+    expect(textContents).toContain(
+      "No local history saved on this device yet.",
+    );
+    expect(action.props.disabled).toBe(true);
+
+    renderer.unmount();
+  });
+
+  it("renders the in-progress state", () => {
+    mockUseLegacyHistoryImport.mockReturnValue({
+      claimantOptions: [
+        {
+          id: "alex-session-a",
+          name: "Alex Example",
+          normalizedName: "alex example",
+          sessionIds: ["session-a"],
+          sessionCount: 1,
+          sourceParticipantIds: ["alex-session-a"],
+          sessionParticipantIds: { "session-a": ["alex-session-a"] },
+          ambiguousSessionIds: [],
+        },
+      ],
+      historySessionCount: 1,
+      hasLocalHistory: true,
+      isConfigured: true,
+      isAuthenticated: true,
+      authChecked: true,
+      isImporting: true,
+      importPhase: "importing",
+      canStartImport: false,
+      canRetryImport: false,
+      availabilityReason: null,
+      importError: null,
+      importResult: null,
+      importHistory: jest.fn(),
+    });
+
+    const LegacyHistoryImportSection =
+      require("../../../components/preferences/LegacyHistoryImportSection").default;
+
+    const renderer = TestRenderer.create(
+      React.createElement(LegacyHistoryImportSection),
+    );
+
+    const { Text } = require("react-native");
+    const textContents = renderer.root
+      .findAllByType(Text)
+      .flatMap((node: any) => node.props.children);
+    const action = renderer.root.findByProps({
+      testID: "LegacyHistoryImportButton",
+    });
+
+    expect(textContents).toContain("Importing...");
+    expect(action.props.disabled).toBe(true);
+
+    renderer.unmount();
+  });
+
+  it("starts the import after the user selects a claimant", async () => {
+    const importHistory = jest.fn().mockResolvedValue(null);
+    const claimant = {
+      id: "alex-session-a",
+      name: "Alex Example",
+      normalizedName: "alex example",
+      sessionIds: ["session-a", "session-b"],
+      sessionCount: 2,
+      sourceParticipantIds: ["alex-session-a", "alex-session-b"],
+      sessionParticipantIds: {
+        "session-a": ["alex-session-a"],
+        "session-b": ["alex-session-b"],
+      },
+      ambiguousSessionIds: [],
+    };
+
+    mockUseLegacyHistoryImport.mockReturnValue({
+      claimantOptions: [claimant],
+      historySessionCount: 2,
+      hasLocalHistory: true,
+      isConfigured: true,
+      isAuthenticated: true,
+      authChecked: true,
+      isImporting: false,
+      importPhase: "ready",
+      canStartImport: true,
+      canRetryImport: false,
+      availabilityReason: null,
+      importError: null,
+      importResult: null,
+      importHistory,
+    });
+
+    const LegacyHistoryImportSection =
+      require("../../../components/preferences/LegacyHistoryImportSection").default;
+
+    const renderer = TestRenderer.create(
+      React.createElement(LegacyHistoryImportSection),
+    );
+
+    await TestRenderer.act(async () => {
+      renderer.root
+        .findByProps({ testID: "LegacyHistoryImportButton" })
+        .props.onPress();
+    });
+
+    await TestRenderer.act(async () => {
+      renderer.root
+        .findByProps({ testID: "LegacyHistoryClaimantOption-alex-session-a" })
+        .props.onPress();
+    });
+
+    expect(importHistory).toHaveBeenCalledWith(claimant);
+
+    renderer.unmount();
+  });
+
+  it("renders the completed state and disables the action", () => {
+    mockUseLegacyHistoryImport.mockReturnValue({
+      claimantOptions: [
+        {
+          id: "alex-session-a",
+          name: "Alex Example",
+          normalizedName: "alex example",
+          sessionIds: ["session-a"],
+          sessionCount: 1,
+          sourceParticipantIds: ["alex-session-a"],
+          sessionParticipantIds: { "session-a": ["alex-session-a"] },
+          ambiguousSessionIds: [],
+        },
+      ],
+      historySessionCount: 1,
+      hasLocalHistory: true,
+      isConfigured: true,
+      isAuthenticated: true,
+      authChecked: true,
+      isImporting: false,
+      importPhase: "completed",
+      canStartImport: false,
+      canRetryImport: false,
+      availabilityReason: null,
+      importError: null,
+      importResult: {
+        importState: "completed",
+        summary: {
+          importedCount: 1,
+          skippedCount: 0,
+          failedCount: 0,
+        },
+        sessions: [],
+      },
+      importHistory: jest.fn(),
+    });
+
+    const LegacyHistoryImportSection =
+      require("../../../components/preferences/LegacyHistoryImportSection").default;
+
+    const renderer = TestRenderer.create(
+      React.createElement(LegacyHistoryImportSection),
+    );
+
+    const { Text } = require("react-native");
+    const textContents = renderer.root
+      .findAllByType(Text)
+      .flatMap((node: any) => node.props.children);
+    const action = renderer.root.findByProps({
+      testID: "LegacyHistoryImportButton",
+    });
+
+    expect(textContents).toContain(
+      "Import completed successfully. Imported 1, skipped 0, failed 0.",
+    );
+    expect(textContents).toContain("Imported");
+    expect(action.props.disabled).toBe(true);
+    expect(action.props.label).toBe("Import Complete");
+
+    renderer.unmount();
+  });
+
+  it("renders the retry state after a failed import", () => {
+    mockUseLegacyHistoryImport.mockReturnValue({
+      claimantOptions: [
+        {
+          id: "alex-session-a",
+          name: "Alex Example",
+          normalizedName: "alex example",
+          sessionIds: ["session-a"],
+          sessionCount: 1,
+          sourceParticipantIds: ["alex-session-a"],
+          sessionParticipantIds: { "session-a": ["alex-session-a"] },
+          ambiguousSessionIds: [],
+        },
+      ],
+      historySessionCount: 1,
+      hasLocalHistory: true,
+      isConfigured: true,
+      isAuthenticated: true,
+      authChecked: true,
+      isImporting: false,
+      importPhase: "failed",
+      canStartImport: true,
+      canRetryImport: true,
+      availabilityReason: null,
+      importError: null,
+      importResult: {
+        importState: "failed",
+        summary: {
+          importedCount: 0,
+          skippedCount: 0,
+          failedCount: 1,
+        },
+        sessions: [],
+      },
+      importHistory: jest.fn(),
+    });
+
+    const LegacyHistoryImportSection =
+      require("../../../components/preferences/LegacyHistoryImportSection").default;
+
+    const renderer = TestRenderer.create(
+      React.createElement(LegacyHistoryImportSection),
+    );
+
+    const { Text } = require("react-native");
+    const textContents = renderer.root
+      .findAllByType(Text)
+      .flatMap((node: any) => node.props.children);
+    const action = renderer.root.findByProps({
+      testID: "LegacyHistoryImportButton",
+    });
+
+    expect(textContents).toContain(
+      "Import finished with failures. Imported 0, skipped 0, failed 1. Retry the claimant selection to try again.",
+    );
+    expect(action.props.disabled).toBe(false);
+    expect(action.props.label).toBe("Retry Import");
+
+    renderer.unmount();
+  });
+
+  it("shows ambiguous claimant guardrails in the claimant modal", () => {
+    const LegacyHistoryImportClaimantModal =
+      require("../../../components/preferences/LegacyHistoryImportClaimantModal").default;
+
+    const renderer = TestRenderer.create(
+      React.createElement(LegacyHistoryImportClaimantModal, {
+        visible: true,
+        isImporting: false,
+        onClose: jest.fn(),
+        onSelectClaimant: jest.fn(),
+        claimantOptions: [
+          {
+            id: "chris-session-a",
+            name: "Chris",
+            normalizedName: "chris",
+            sessionIds: ["session-a"],
+            sessionCount: 1,
+            sourceParticipantIds: ["chris-session-a", "chris-session-b"],
+            sessionParticipantIds: {
+              "session-a": ["chris-session-a", "chris-session-b"],
+            },
+            ambiguousSessionIds: ["session-a"],
+          },
+        ],
+      }),
+    );
+
+    const option = renderer.root.findByProps({
+      testID: "LegacyHistoryClaimantOption-chris-session-a",
+    });
+    const { Text } = require("react-native");
+    const textContents = renderer.root
+      .findAllByType(Text)
+      .flatMap((node: any) => node.props.children);
+
+    expect(option.props.disabled).toBe(true);
+    expect(textContents).toContain(
+      "Unavailable: duplicate name in 1 saved session.",
+    );
+
+    renderer.unmount();
+  });
+});

--- a/__tests__/utils/legacyHistoryImport.test.ts
+++ b/__tests__/utils/legacyHistoryImport.test.ts
@@ -1,0 +1,316 @@
+import type { LegacyLocalSessionSnapshot } from "../../types/legacyHistoryImport";
+import {
+  buildLegacyHistoryClaimantOptions,
+  buildLegacyHistoryImportRequest,
+  buildLegacyHistorySourceFingerprintInput,
+  normalizeLegacyHistoryParticipantName,
+} from "../../utils/legacyHistoryImport";
+
+const buildSession = (
+  overrides: Partial<LegacyLocalSessionSnapshot>,
+): LegacyLocalSessionSnapshot => {
+  return {
+    id: "session-default",
+    date: "2026-05-01T18:00:00.000Z",
+    players: [],
+    matches: [],
+    commonMatchId: null,
+    playerAssignments: {},
+    matchesPerPlayer: 1,
+    ...overrides,
+  };
+};
+
+describe("legacyHistoryImport", () => {
+  it("normalizes claimant names for stable grouping", () => {
+    expect(normalizeLegacyHistoryParticipantName("  Alex   Example  ")).toBe(
+      "alex example",
+    );
+  });
+
+  it("groups claimant options by normalized name across session-local ids", () => {
+    const sessions: LegacyLocalSessionSnapshot[] = [
+      buildSession({
+        id: "session-b",
+        date: "2026-05-02T18:00:00.000Z",
+        players: [
+          { id: "alex-session-b", name: "Alex Example", drinksTaken: 4 },
+          { id: "jordan-session-b", name: "Jordan Guest", drinksTaken: 2 },
+        ],
+      }),
+      buildSession({
+        id: "session-a",
+        date: "2026-05-01T18:00:00.000Z",
+        players: [
+          { id: "jordan-session-a", name: "Jordan Guest", drinksTaken: 1 },
+          { id: "alex-session-a", name: " alex   example ", drinksTaken: 3 },
+        ],
+      }),
+    ];
+
+    const claimantOptions = buildLegacyHistoryClaimantOptions(sessions);
+    const alexOption = claimantOptions.find(
+      (option) => option.name === "Alex Example",
+    );
+
+    expect(alexOption).toEqual({
+      id: "alex-session-a",
+      name: "Alex Example",
+      normalizedName: "alex example",
+      sessionIds: ["session-a", "session-b"],
+      sessionCount: 2,
+      sourceParticipantIds: ["alex-session-a", "alex-session-b"],
+      sessionParticipantIds: {
+        "session-a": ["alex-session-a"],
+        "session-b": ["alex-session-b"],
+      },
+      ambiguousSessionIds: [],
+    });
+  });
+
+  it("builds deterministic fingerprint inputs and session-specific claimant payloads", () => {
+    const sessions: LegacyLocalSessionSnapshot[] = [
+      buildSession({
+        id: "session-b",
+        date: "2026-05-02T18:00:00.000Z",
+        players: [
+          { id: "jordan-session-b", name: "Jordan Guest", drinksTaken: 2 },
+          { id: "alex-session-b", name: "Alex Example", drinksTaken: 4 },
+        ],
+        matches: [
+          {
+            id: "match-b-2",
+            homeTeam: "Team Two",
+            awayTeam: "Team Three",
+            homeGoals: 2,
+            awayGoals: 0,
+            startTime: "2026-05-02T19:00:00.000Z",
+          },
+          {
+            id: "match-b-1",
+            homeTeam: "Team One",
+            awayTeam: "Team Two",
+            homeGoals: 1,
+            awayGoals: 1,
+            startTime: "2026-05-02T18:00:00.000Z",
+          },
+        ],
+        commonMatchId: "match-b-1",
+        playerAssignments: {
+          "jordan-session-b": ["match-b-2", "match-b-1"],
+          "alex-session-b": ["match-b-2", "match-b-1"],
+        },
+        matchesPerPlayer: 2,
+      }),
+      buildSession({
+        id: "session-a",
+        date: "2026-05-01T18:00:00.000Z",
+        players: [
+          { id: "jordan-session-a", name: "Jordan Guest", drinksTaken: 1 },
+          { id: "alex-session-a", name: "Alex Example", drinksTaken: 3 },
+        ],
+        matches: [
+          {
+            id: "match-a-1",
+            homeTeam: "Alpha",
+            awayTeam: "Beta",
+            homeGoals: 3,
+            awayGoals: 2,
+            startTime: "2026-05-01T18:00:00.000Z",
+          },
+        ],
+        commonMatchId: "match-a-1",
+        playerAssignments: {
+          "jordan-session-a": ["match-a-1"],
+          "alex-session-a": ["match-a-1"],
+        },
+      }),
+      buildSession({
+        id: "session-c",
+        date: "2026-05-03T18:00:00.000Z",
+        players: [
+          { id: "morgan-session-c", name: "Morgan Only", drinksTaken: 5 },
+        ],
+        matches: [
+          {
+            id: "match-c-1",
+            homeTeam: "Gamma",
+            awayTeam: "Delta",
+            homeGoals: 0,
+            awayGoals: 0,
+            startTime: "2026-05-03T18:00:00.000Z",
+          },
+        ],
+        playerAssignments: {
+          "morgan-session-c": ["match-c-1"],
+        },
+      }),
+    ];
+
+    expect(buildLegacyHistorySourceFingerprintInput(sessions[0])).toEqual({
+      sourceLocalSessionId: "session-b",
+      savedAt: "2026-05-02T18:00:00.000Z",
+      commonMatchId: "match-b-1",
+      matchesPerPlayer: 2,
+      players: [
+        { id: "alex-session-b", name: "Alex Example", drinksTaken: 4 },
+        { id: "jordan-session-b", name: "Jordan Guest", drinksTaken: 2 },
+      ],
+      matches: [
+        {
+          id: "match-b-1",
+          homeTeam: "Team One",
+          awayTeam: "Team Two",
+          homeGoals: 1,
+          awayGoals: 1,
+          startTime: "2026-05-02T18:00:00.000Z",
+        },
+        {
+          id: "match-b-2",
+          homeTeam: "Team Two",
+          awayTeam: "Team Three",
+          homeGoals: 2,
+          awayGoals: 0,
+          startTime: "2026-05-02T19:00:00.000Z",
+        },
+      ],
+      playerAssignments: {
+        "alex-session-b": ["match-b-1", "match-b-2"],
+        "jordan-session-b": ["match-b-1", "match-b-2"],
+      },
+    });
+
+    const claimant = buildLegacyHistoryClaimantOptions(sessions).find(
+      (option) => option.name === "Alex Example",
+    );
+
+    expect(claimant).toBeDefined();
+
+    const request = buildLegacyHistoryImportRequest({
+      sessions,
+      claimant: claimant!,
+    });
+
+    expect(request.claimedLocalParticipantId).toBe("alex-session-a");
+    expect(request.sessions).toHaveLength(2);
+    expect(
+      request.sessions.map((session) => session.sourceLocalSessionId),
+    ).toEqual(["session-a", "session-b"]);
+    expect(
+      request.sessions.map((session) => session.claimedLocalParticipantId),
+    ).toEqual(["alex-session-a", "alex-session-b"]);
+    expect(request.sessions[1].players).toEqual([
+      { id: "alex-session-b", name: "Alex Example", drinksTaken: 4 },
+      { id: "jordan-session-b", name: "Jordan Guest", drinksTaken: 2 },
+    ]);
+  });
+
+  it("preserves guest participants as session-scoped snapshots in the request payload", () => {
+    const sessions: LegacyLocalSessionSnapshot[] = [
+      buildSession({
+        id: "session-a",
+        date: "2026-05-01T18:00:00.000Z",
+        players: [
+          { id: "alex-session-a", name: "Alex Example", drinksTaken: 3 },
+          { id: "jordan-session-a", name: "Jordan Guest", drinksTaken: 1 },
+        ],
+        matches: [
+          {
+            id: "match-a-1",
+            homeTeam: "Alpha",
+            awayTeam: "Beta",
+            homeGoals: 3,
+            awayGoals: 2,
+            startTime: "2026-05-01T18:00:00.000Z",
+          },
+        ],
+        commonMatchId: "match-a-1",
+        playerAssignments: {
+          "alex-session-a": ["match-a-1"],
+          "jordan-session-a": ["match-a-1"],
+        },
+      }),
+      buildSession({
+        id: "session-b",
+        date: "2026-05-02T18:00:00.000Z",
+        players: [
+          { id: "alex-session-b", name: "Alex Example", drinksTaken: 4 },
+          { id: "jordan-session-b", name: "Jordan Guest", drinksTaken: 2 },
+        ],
+        matches: [
+          {
+            id: "match-b-1",
+            homeTeam: "Team One",
+            awayTeam: "Team Two",
+            homeGoals: 1,
+            awayGoals: 1,
+            startTime: "2026-05-02T18:00:00.000Z",
+          },
+        ],
+        commonMatchId: "match-b-1",
+        playerAssignments: {
+          "alex-session-b": ["match-b-1"],
+          "jordan-session-b": ["match-b-1"],
+        },
+      }),
+    ];
+
+    const claimant = buildLegacyHistoryClaimantOptions(sessions).find(
+      (option) => option.name === "Alex Example",
+    );
+
+    expect(claimant).toBeDefined();
+
+    const request = buildLegacyHistoryImportRequest({
+      sessions,
+      claimant: claimant!,
+    });
+
+    expect(request.sessions).toEqual([
+      expect.objectContaining({
+        sourceLocalSessionId: "session-a",
+        claimedLocalParticipantId: "alex-session-a",
+        guestParticipants: [
+          { id: "jordan-session-a", name: "Jordan Guest", drinksTaken: 1 },
+        ],
+      }),
+      expect.objectContaining({
+        sourceLocalSessionId: "session-b",
+        claimedLocalParticipantId: "alex-session-b",
+        guestParticipants: [
+          { id: "jordan-session-b", name: "Jordan Guest", drinksTaken: 2 },
+        ],
+      }),
+    ]);
+
+    expect(
+      request.sessions.every((session) =>
+        session.guestParticipants.every(
+          (participant) => participant.id !== session.claimedLocalParticipantId,
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects claimant options that are ambiguous inside a single session", () => {
+    const sessions: LegacyLocalSessionSnapshot[] = [
+      buildSession({
+        id: "ambiguous-session",
+        players: [
+          { id: "chris-1", name: "Chris", drinksTaken: 1 },
+          { id: "chris-2", name: "  Chris  ", drinksTaken: 2 },
+        ],
+      }),
+    ];
+
+    const claimant = buildLegacyHistoryClaimantOptions(sessions)[0];
+
+    expect(claimant.ambiguousSessionIds).toEqual(["ambiguous-session"]);
+    expect(() =>
+      buildLegacyHistoryImportRequest({
+        sessions,
+        claimant,
+      }),
+    ).toThrow("Claimant Chris is ambiguous in 1 legacy session(s).");
+  });
+});

--- a/app/style/userPreferencesStyles.ts
+++ b/app/style/userPreferencesStyles.ts
@@ -1,8 +1,8 @@
-import { StyleSheet, ViewStyle, TextStyle } from "react-native";
+import { StyleSheet, TextStyle, ViewStyle } from "react-native";
 import { useColors } from "./theme";
 
 export const createUserPreferencesStyles = (
-  colors: ReturnType<typeof useColors>
+  colors: ReturnType<typeof useColors>,
 ) => {
   const baseContainer: ViewStyle = {
     flex: 1,
@@ -810,6 +810,160 @@ export const createUserPreferencesStyles = (
     },
   });
 
+  const legacyHistoryImportStyles = StyleSheet.create({
+    description: {
+      fontSize: 14,
+      color: colors.textSecondary,
+      lineHeight: 20,
+    },
+    summaryRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      marginTop: 12,
+    },
+    summaryLabel: {
+      fontSize: 14,
+      color: colors.textSecondary,
+    },
+    summaryValue: {
+      fontSize: 14,
+      fontWeight: "600",
+      color: colors.textPrimary,
+    },
+    statusPanel: {
+      marginTop: 14,
+      padding: 14,
+      borderRadius: 12,
+      backgroundColor: colors.backgroundSubtle,
+      borderWidth: 1,
+      borderColor: colors.borderSubtle,
+    },
+    statusText: {
+      fontSize: 14,
+      lineHeight: 20,
+      color: colors.textSecondary,
+    },
+    statusTextSuccess: {
+      color: colors.success,
+    },
+    statusTextError: {
+      color: colors.danger,
+    },
+    warningText: {
+      marginTop: 12,
+      fontSize: 13,
+      lineHeight: 18,
+      color: colors.warning,
+    },
+    resultSummaryRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      marginTop: 10,
+    },
+    resultSummaryLabel: {
+      fontSize: 13,
+      color: colors.textSecondary,
+    },
+    resultSummaryValue: {
+      fontSize: 13,
+      fontWeight: "600",
+      color: colors.textPrimary,
+    },
+    buttonContainer: {
+      marginTop: 16,
+    },
+    modalSafeArea: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    modalHeader: {
+      ...baseRow,
+      minHeight: 56,
+      paddingVertical: 10,
+      backgroundColor: colors.surface,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.borderSubtle,
+    },
+    modalHeaderTitle: {
+      fontSize: 18,
+      fontWeight: "600",
+      color: colors.textPrimary,
+      marginLeft: 8,
+    },
+    modalCloseButton: {
+      padding: 8,
+    },
+    modalContent: {
+      flex: 1,
+      paddingHorizontal: 16,
+      paddingTop: 16,
+      paddingBottom: 24,
+    },
+    modalDescription: {
+      fontSize: 14,
+      lineHeight: 20,
+      color: colors.textSecondary,
+      marginBottom: 16,
+    },
+    claimantOptionRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      paddingVertical: 14,
+      paddingHorizontal: 14,
+      marginBottom: 10,
+      borderRadius: 12,
+      backgroundColor: colors.surface,
+      borderWidth: 1,
+      borderColor: colors.borderSubtle,
+    },
+    claimantOptionRowDisabled: {
+      opacity: 0.6,
+      backgroundColor: colors.backgroundSubtle,
+    },
+    claimantOptionContent: {
+      flex: 1,
+      marginRight: 12,
+    },
+    claimantOptionName: {
+      fontSize: 16,
+      fontWeight: "600",
+      color: colors.textPrimary,
+    },
+    claimantOptionMeta: {
+      marginTop: 4,
+      fontSize: 13,
+      color: colors.textSecondary,
+    },
+    claimantOptionWarning: {
+      marginTop: 6,
+      fontSize: 12,
+      lineHeight: 17,
+      color: colors.warning,
+    },
+    modalEmptyState: {
+      flex: 1,
+      alignItems: "center",
+      justifyContent: "center",
+      paddingHorizontal: 24,
+    },
+    modalEmptyTitle: {
+      fontSize: 18,
+      fontWeight: "600",
+      color: colors.textPrimary,
+      marginBottom: 8,
+      textAlign: "center",
+    },
+    modalEmptyMessage: {
+      fontSize: 14,
+      lineHeight: 20,
+      color: colors.textSecondary,
+      textAlign: "center",
+    },
+  });
+
   return {
     commonStyles,
     headerStyles,
@@ -817,6 +971,7 @@ export const createUserPreferencesStyles = (
     addLeagueModalStyles,
     manageLeaguesModalStyles,
     selectDefaultLeaguesModalStyles,
+    legacyHistoryImportStyles,
   } as const;
 };
 

--- a/app/userPreferences.tsx
+++ b/app/userPreferences.tsx
@@ -10,6 +10,7 @@ import AddLeagueModal from "../components/preferences/AddLeagueModal";
 import AppearanceSettings from "../components/preferences/AppearanceSettings";
 import Header from "../components/preferences/Header";
 import LeagueSettings from "../components/preferences/LeagueSettings";
+import LegacyHistoryImportSection from "../components/preferences/LegacyHistoryImportSection";
 import ManageLeaguesModal from "../components/preferences/ManageLeaguesModal";
 import OnboardingButton from "../components/preferences/OnboardingButton";
 import SelectDefaultLeaguesModal from "../components/preferences/SelectDefaultLeaguesModal";
@@ -128,6 +129,8 @@ const UserPreferencesScreen = () => {
               setShowSelectDefaultLeaguesModal(true)
             }
           />
+
+          <LegacyHistoryImportSection />
 
           <OnboardingButton onPress={() => setShowOnboarding(true)} />
         </ScrollView>

--- a/components/preferences/LegacyHistoryImportClaimantModal.tsx
+++ b/components/preferences/LegacyHistoryImportClaimantModal.tsx
@@ -1,0 +1,154 @@
+import { Ionicons } from "@expo/vector-icons";
+import React from "react";
+import {
+  FlatList,
+  Modal,
+  SafeAreaView,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+import { useColors } from "../../app/style/theme";
+import { createUserPreferencesStyles } from "../../app/style/userPreferencesStyles";
+import type { LegacyHistoryDerivedClaimantOption } from "../../utils/legacyHistoryImport";
+
+interface LegacyHistoryImportClaimantModalProps {
+  visible: boolean;
+  claimantOptions: LegacyHistoryDerivedClaimantOption[];
+  isImporting: boolean;
+  onClose: () => void;
+  onSelectClaimant: (
+    claimant: LegacyHistoryDerivedClaimantOption,
+  ) => Promise<void> | void;
+}
+
+const formatSessionCount = (sessionCount: number) => {
+  return `${sessionCount} saved session${sessionCount === 1 ? "" : "s"}`;
+};
+
+const formatAmbiguousSessionCount = (ambiguousSessionCount: number) => {
+  return `Unavailable: duplicate name in ${ambiguousSessionCount} saved session${
+    ambiguousSessionCount === 1 ? "" : "s"
+  }.`;
+};
+
+const LegacyHistoryImportClaimantModal: React.FC<
+  LegacyHistoryImportClaimantModalProps
+> = ({ visible, claimantOptions, isImporting, onClose, onSelectClaimant }) => {
+  const colors = useColors();
+  const { legacyHistoryImportStyles } = React.useMemo(
+    () => createUserPreferencesStyles(colors),
+    [colors],
+  );
+
+  const hasClaimantOptions = claimantOptions.length > 0;
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent={false}
+      onRequestClose={onClose}
+    >
+      <SafeAreaView
+        style={legacyHistoryImportStyles.modalSafeArea}
+        testID="LegacyHistoryImportClaimantModal"
+      >
+        <View style={legacyHistoryImportStyles.modalHeader}>
+          <TouchableOpacity
+            onPress={onClose}
+            style={legacyHistoryImportStyles.modalCloseButton}
+            testID="LegacyHistoryImportClaimantModalClose"
+          >
+            <Ionicons name="arrow-back" size={24} color={colors.primary} />
+          </TouchableOpacity>
+          <Text style={legacyHistoryImportStyles.modalHeaderTitle}>
+            Choose Your Player
+          </Text>
+          <View style={{ width: 44 }} />
+        </View>
+
+        <View style={legacyHistoryImportStyles.modalContent}>
+          <Text style={legacyHistoryImportStyles.modalDescription}>
+            Pick the local participant that should be linked to your signed-in
+            account. Everyone else stays as a session-scoped guest snapshot.
+          </Text>
+
+          {hasClaimantOptions ? (
+            <FlatList
+              data={claimantOptions}
+              keyExtractor={(item) => item.normalizedName}
+              renderItem={({ item }) => {
+                const isAmbiguous = item.ambiguousSessionIds.length > 0;
+
+                return (
+                  <TouchableOpacity
+                    testID={`LegacyHistoryClaimantOption-${item.id}`}
+                    style={[
+                      legacyHistoryImportStyles.claimantOptionRow,
+                      isAmbiguous
+                        ? legacyHistoryImportStyles.claimantOptionRowDisabled
+                        : null,
+                    ]}
+                    disabled={isAmbiguous || isImporting}
+                    onPress={() => {
+                      void onSelectClaimant(item);
+                    }}
+                  >
+                    <View
+                      style={legacyHistoryImportStyles.claimantOptionContent}
+                    >
+                      <Text
+                        style={legacyHistoryImportStyles.claimantOptionName}
+                      >
+                        {item.name}
+                      </Text>
+                      <Text
+                        style={legacyHistoryImportStyles.claimantOptionMeta}
+                      >
+                        {formatSessionCount(item.sessionCount)}
+                      </Text>
+                      {isAmbiguous ? (
+                        <Text
+                          style={
+                            legacyHistoryImportStyles.claimantOptionWarning
+                          }
+                        >
+                          {formatAmbiguousSessionCount(
+                            item.ambiguousSessionIds.length,
+                          )}
+                        </Text>
+                      ) : null}
+                    </View>
+
+                    <Ionicons
+                      name={
+                        isAmbiguous ? "warning-outline" : "cloud-upload-outline"
+                      }
+                      size={20}
+                      color={isAmbiguous ? colors.warning : colors.primary}
+                    />
+                  </TouchableOpacity>
+                );
+              }}
+              showsVerticalScrollIndicator={false}
+            />
+          ) : (
+            <View style={legacyHistoryImportStyles.modalEmptyState}>
+              <Text style={legacyHistoryImportStyles.modalEmptyTitle}>
+                No Claimant Options Available
+              </Text>
+              <Text style={legacyHistoryImportStyles.modalEmptyMessage}>
+                Save at least one local session with named participants before
+                starting the import.
+              </Text>
+            </View>
+          )}
+        </View>
+      </SafeAreaView>
+    </Modal>
+  );
+};
+
+export default LegacyHistoryImportClaimantModal;

--- a/components/preferences/LegacyHistoryImportSection.tsx
+++ b/components/preferences/LegacyHistoryImportSection.tsx
@@ -1,0 +1,279 @@
+import { Ionicons } from "@expo/vector-icons";
+import React, { useState } from "react";
+import { Text, View } from "react-native";
+
+import { useColors } from "../../app/style/theme";
+import { createUserPreferencesStyles } from "../../app/style/userPreferencesStyles";
+import { useLegacyHistoryImport } from "../../hooks/useLegacyHistoryImport";
+import { ShellActionButton, ShellCard, ShellSection } from "../ui";
+import LegacyHistoryImportClaimantModal from "./LegacyHistoryImportClaimantModal";
+
+const formatSummaryCount = (count: number) => {
+  return count.toString();
+};
+
+const formatImportStatus = (
+  importedCount: number,
+  skippedCount: number,
+  failedCount: number,
+) => {
+  return `Imported ${importedCount}, skipped ${skippedCount}, failed ${failedCount}.`;
+};
+
+const buildStatusMessage = ({
+  importError,
+  importResult,
+  importPhase,
+  isCheckingAvailability,
+  hasLocalHistory,
+  hasClaimantOptions,
+  availabilityReason,
+}: {
+  importError: string | null;
+  importResult: ReturnType<typeof useLegacyHistoryImport>["importResult"];
+  importPhase: ReturnType<typeof useLegacyHistoryImport>["importPhase"];
+  isCheckingAvailability: boolean;
+  hasLocalHistory: boolean;
+  hasClaimantOptions: boolean;
+  availabilityReason: string | null;
+}) => {
+  if (importError) {
+    return importError;
+  }
+
+  if (importResult) {
+    if (importPhase === "completed") {
+      return `Import completed successfully. ${formatImportStatus(
+        importResult.summary.importedCount,
+        importResult.summary.skippedCount,
+        importResult.summary.failedCount,
+      )}`;
+    }
+
+    if (importPhase === "failed") {
+      return `Import finished with failures. ${formatImportStatus(
+        importResult.summary.importedCount,
+        importResult.summary.skippedCount,
+        importResult.summary.failedCount,
+      )} Retry the claimant selection to try again.`;
+    }
+
+    return formatImportStatus(
+      importResult.summary.importedCount,
+      importResult.summary.skippedCount,
+      importResult.summary.failedCount,
+    );
+  }
+
+  if (isCheckingAvailability) {
+    return "Checking cloud access...";
+  }
+
+  if (!hasLocalHistory) {
+    return "No local history saved on this device yet.";
+  }
+
+  if (!hasClaimantOptions) {
+    return "No eligible participants were found in your saved history.";
+  }
+
+  if (availabilityReason) {
+    return availabilityReason;
+  }
+
+  return "Choose which saved participant should represent your cloud account, then start the one-time import.";
+};
+
+const getButtonLabel = (
+  isImporting: boolean,
+  importPhase: ReturnType<typeof useLegacyHistoryImport>["importPhase"],
+) => {
+  if (isImporting) {
+    return "Importing...";
+  }
+
+  if (importPhase === "completed") {
+    return "Import Complete";
+  }
+
+  if (importPhase === "failed") {
+    return "Retry Import";
+  }
+
+  return "Import Local History";
+};
+
+const LegacyHistoryImportSection: React.FC = () => {
+  const colors = useColors();
+  const { legacyHistoryImportStyles } = React.useMemo(
+    () => createUserPreferencesStyles(colors),
+    [colors],
+  );
+  const [showClaimantModal, setShowClaimantModal] = useState(false);
+
+  const {
+    claimantOptions,
+    historySessionCount,
+    hasLocalHistory,
+    isConfigured,
+    authChecked,
+    isImporting,
+    importPhase,
+    canStartImport,
+    canRetryImport,
+    availabilityReason,
+    importError,
+    importResult,
+    importHistory,
+  } = useLegacyHistoryImport();
+
+  const isCheckingAvailability = isConfigured && !authChecked;
+  const hasClaimantOptions = claimantOptions.length > 0;
+  const hasAmbiguousClaimants = claimantOptions.some(
+    (option) => option.ambiguousSessionIds.length > 0,
+  );
+  let buttonVariant: "primary" | "secondary" | "success" = "primary";
+
+  if (importPhase === "completed") {
+    buttonVariant = "success";
+  } else if (canRetryImport) {
+    buttonVariant = "secondary";
+  }
+
+  let buttonIconName:
+    | "checkmark-circle-outline"
+    | "refresh-outline"
+    | "cloud-upload-outline" = "cloud-upload-outline";
+
+  if (importPhase === "completed") {
+    buttonIconName = "checkmark-circle-outline";
+  } else if (canRetryImport) {
+    buttonIconName = "refresh-outline";
+  }
+
+  const statusMessage = buildStatusMessage({
+    importError,
+    importResult,
+    importPhase,
+    isCheckingAvailability,
+    hasLocalHistory,
+    hasClaimantOptions,
+    availabilityReason,
+  });
+
+  let statusTextStyle;
+
+  if (importError) {
+    statusTextStyle = legacyHistoryImportStyles.statusTextError;
+  } else if (importResult) {
+    statusTextStyle = legacyHistoryImportStyles.statusTextSuccess;
+  }
+
+  const actionDisabled =
+    !canStartImport || isCheckingAvailability || Boolean(availabilityReason);
+
+  const buttonLabel = getButtonLabel(isImporting, importPhase);
+
+  return (
+    <ShellSection title="History Import" marginBottom="$3">
+      <ShellCard compact testID="LegacyHistoryImportSection">
+        <Text style={legacyHistoryImportStyles.description}>
+          Import the sessions saved on this device into your cloud account once.
+        </Text>
+
+        <View style={legacyHistoryImportStyles.summaryRow}>
+          <Text style={legacyHistoryImportStyles.summaryLabel}>
+            Saved sessions
+          </Text>
+          <Text style={legacyHistoryImportStyles.summaryValue}>
+            {formatSummaryCount(historySessionCount)}
+          </Text>
+        </View>
+
+        <View style={legacyHistoryImportStyles.summaryRow}>
+          <Text style={legacyHistoryImportStyles.summaryLabel}>
+            Claimant options
+          </Text>
+          <Text style={legacyHistoryImportStyles.summaryValue}>
+            {formatSummaryCount(claimantOptions.length)}
+          </Text>
+        </View>
+
+        {hasAmbiguousClaimants ? (
+          <Text style={legacyHistoryImportStyles.warningText}>
+            Some names appear more than once inside a saved session and cannot
+            be claimed safely.
+          </Text>
+        ) : null}
+
+        <View style={legacyHistoryImportStyles.statusPanel}>
+          <Text
+            style={[legacyHistoryImportStyles.statusText, statusTextStyle]}
+            testID="LegacyHistoryImportStatus"
+          >
+            {statusMessage}
+          </Text>
+
+          {importResult ? (
+            <>
+              <View style={legacyHistoryImportStyles.resultSummaryRow}>
+                <Text style={legacyHistoryImportStyles.resultSummaryLabel}>
+                  Imported
+                </Text>
+                <Text style={legacyHistoryImportStyles.resultSummaryValue}>
+                  {formatSummaryCount(importResult.summary.importedCount)}
+                </Text>
+              </View>
+              <View style={legacyHistoryImportStyles.resultSummaryRow}>
+                <Text style={legacyHistoryImportStyles.resultSummaryLabel}>
+                  Skipped
+                </Text>
+                <Text style={legacyHistoryImportStyles.resultSummaryValue}>
+                  {formatSummaryCount(importResult.summary.skippedCount)}
+                </Text>
+              </View>
+              <View style={legacyHistoryImportStyles.resultSummaryRow}>
+                <Text style={legacyHistoryImportStyles.resultSummaryLabel}>
+                  Failed
+                </Text>
+                <Text style={legacyHistoryImportStyles.resultSummaryValue}>
+                  {formatSummaryCount(importResult.summary.failedCount)}
+                </Text>
+              </View>
+            </>
+          ) : null}
+        </View>
+
+        <View style={legacyHistoryImportStyles.buttonContainer}>
+          <ShellActionButton
+            testID="LegacyHistoryImportButton"
+            label={buttonLabel}
+            variant={buttonVariant}
+            disabled={actionDisabled}
+            onPress={() => setShowClaimantModal(true)}
+            icon={
+              <Ionicons
+                name={buttonIconName}
+                size={18}
+                color={colors.textLight}
+              />
+            }
+          />
+        </View>
+      </ShellCard>
+
+      <LegacyHistoryImportClaimantModal
+        visible={showClaimantModal}
+        claimantOptions={claimantOptions}
+        isImporting={isImporting}
+        onClose={() => setShowClaimantModal(false)}
+        onSelectClaimant={async (claimant) => {
+          setShowClaimantModal(false);
+          await importHistory(claimant);
+        }}
+      />
+    </ShellSection>
+  );
+};
+
+export default LegacyHistoryImportSection;

--- a/e2e/features/legacy-history-import.feature
+++ b/e2e/features/legacy-history-import.feature
@@ -1,0 +1,36 @@
+Feature: Legacy History Import
+
+    Background:
+        Given the app is running on web
+        And the Supabase import service is mocked
+        And the user has a signed-in legacy history ready for import
+
+    Scenario: Import legacy history from Settings
+        When the user navigates to preferences
+        Then the "History Import" section should be visible
+        And the "Import Local History" action should be visible
+        When the user starts the legacy history import
+        Then the claimant picker should be visible
+        When the user selects the "Alex Example" claimant
+        Then the import completion summary should be visible
+        And the "Import Complete" action should be visible
+
+    Scenario: Mixed registered and guest players preserve guest snapshots
+        When the user navigates to preferences
+        Then the "History Import" section should be visible
+        When the user starts the legacy history import
+        Then the claimant picker should be visible
+        When the user selects the "Alex Example" claimant
+        Then the import request should preserve guest participant snapshots
+        And the import completion summary should be visible
+
+    Scenario: Reopening the completed import stays disabled
+        When the user navigates to preferences
+        Then the "History Import" section should be visible
+        When the user starts the legacy history import
+        Then the claimant picker should be visible
+        When the user selects the "Alex Example" claimant
+        Then the import completion summary should be visible
+        When the user tries to start the legacy history import again
+        Then the import action should remain disabled
+        And the import RPC should only be called once

--- a/e2e/steps/browser-flow.helpers.ts
+++ b/e2e/steps/browser-flow.helpers.ts
@@ -1,6 +1,41 @@
 import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+import type {
+  ImportLegacyHistoryRpcRequest,
+  ImportLegacyHistoryRpcResponse,
+  LegacyLocalSessionSnapshot,
+} from "../../types/legacyHistoryImport";
 
 export const PERSISTED_STORE_KEY = "dong-storage" as const;
+
+export const LEGACY_HISTORY_IMPORT_SUPABASE_URL =
+  "http://127.0.0.1:55321" as const;
+
+export const LEGACY_HISTORY_IMPORT_ANON_KEY =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0" as const;
+
+export const LEGACY_HISTORY_IMPORT_PUBLISHABLE_KEY =
+  "sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH" as const;
+
+export const LEGACY_HISTORY_IMPORT_AUTH_STORAGE_KEY =
+  `sb-${new URL(LEGACY_HISTORY_IMPORT_SUPABASE_URL).hostname.split(".")[0]}-auth-token` as const;
+
+export const LEGACY_HISTORY_IMPORT_USER_ID =
+  "11111111-1111-1111-1111-111111111111" as const;
+
+export const LEGACY_HISTORY_IMPORT_USER_EMAIL =
+  "legacy-import@example.com" as const;
+
+let legacyHistoryImportRpcCallCount = 0;
+let legacyHistoryImportRpcLastRequest: ImportLegacyHistoryRpcRequest | null =
+  null;
+
+export const getLegacyHistoryImportRpcCallCount = () =>
+  legacyHistoryImportRpcCallCount;
+
+export const getLegacyHistoryImportRpcLastRequest = () =>
+  legacyHistoryImportRpcLastRequest;
 
 export const HOME_READY_MARKERS = [
   "Start New Game",
@@ -49,6 +84,122 @@ export interface BrowserFlowPersistedState {
   };
   version: 0;
 }
+
+export const createLegacyHistoryImportSessions =
+  (): LegacyLocalSessionSnapshot[] => [
+    {
+      id: "legacy-session-a",
+      date: "2026-05-01T19:00:00.000Z",
+      players: [
+        { id: "alex-session-a", name: "Alex Example", drinksTaken: 2 },
+        { id: "jordan-session-a", name: "Jordan Guest", drinksTaken: 1 },
+      ],
+      matches: [
+        {
+          id: "legacy-match-a-1",
+          homeTeam: "Arsenal",
+          awayTeam: "Chelsea",
+          homeGoals: 2,
+          awayGoals: 1,
+        },
+      ],
+      commonMatchId: "legacy-match-a-1",
+      playerAssignments: {
+        "alex-session-a": ["legacy-match-a-1"],
+        "jordan-session-a": ["legacy-match-a-1"],
+      },
+      matchesPerPlayer: 1,
+    },
+    {
+      id: "legacy-session-b",
+      date: "2026-05-03T19:00:00.000Z",
+      players: [
+        { id: "alex-session-b", name: "Alex Example", drinksTaken: 4 },
+        { id: "jordan-session-b", name: "Jordan Guest", drinksTaken: 3 },
+      ],
+      matches: [
+        {
+          id: "legacy-match-b-1",
+          homeTeam: "Liverpool",
+          awayTeam: "Everton",
+          homeGoals: 3,
+          awayGoals: 2,
+        },
+      ],
+      commonMatchId: "legacy-match-b-1",
+      playerAssignments: {
+        "alex-session-b": ["legacy-match-b-1"],
+        "jordan-session-b": ["legacy-match-b-1"],
+      },
+      matchesPerPlayer: 1,
+    },
+  ];
+
+export const buildLegacyHistoryImportPersistedState = (
+  sessions: LegacyLocalSessionSnapshot[],
+): BrowserFlowPersistedState => ({
+  state: {
+    players: [],
+    matches: [],
+    commonMatchId: null,
+    playerAssignments: {},
+    matchesPerPlayer: 1,
+    history: sessions,
+    theme: "light",
+  },
+  version: 0,
+});
+
+export const buildLegacyHistoryImportAuthSession = () => ({
+  access_token:
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.legacy-import-access-token",
+  refresh_token: "legacy-import-refresh-token",
+  expires_in: 3600,
+  expires_at: Math.floor(Date.now() / 1000) + 3600,
+  token_type: "bearer",
+  user: {
+    id: LEGACY_HISTORY_IMPORT_USER_ID,
+    aud: "authenticated",
+    role: "authenticated",
+    email: LEGACY_HISTORY_IMPORT_USER_EMAIL,
+    app_metadata: {},
+    user_metadata: {},
+    identities: [],
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  },
+});
+
+export const buildLegacyHistoryImportAuthUser = () => ({
+  id: LEGACY_HISTORY_IMPORT_USER_ID,
+  aud: "authenticated",
+  role: "authenticated",
+  email: LEGACY_HISTORY_IMPORT_USER_EMAIL,
+  app_metadata: {},
+  user_metadata: {},
+  identities: [],
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+});
+
+export const buildLegacyHistoryImportResponse = (
+  request: ImportLegacyHistoryRpcRequest,
+): ImportLegacyHistoryRpcResponse => ({
+  accountId: LEGACY_HISTORY_IMPORT_USER_ID,
+  importState: "completed",
+  claimedLocalParticipantId: request.claimedLocalParticipantId,
+  summary: {
+    importedCount: request.sessions.length,
+    skippedCount: 0,
+    failedCount: 0,
+  },
+  sessions: request.sessions.map((session) => ({
+    sourceLocalSessionId: session.sourceLocalSessionId,
+    sourceFingerprint: `fingerprint-${session.sourceLocalSessionId}`,
+    state: "imported",
+    cloudSessionId: `cloud-${session.sourceLocalSessionId}`,
+  })),
+});
 
 export const createSetupJourneyDataset = (
   overrides: Partial<SetupJourneyDataset> = {},
@@ -142,4 +293,64 @@ export const waitForBrowserFlowReady = async (
     markers,
     { timeout: 10_000 },
   );
+};
+
+export const mockLegacyHistoryImportServices = async (page: Page) => {
+  legacyHistoryImportRpcCallCount = 0;
+  legacyHistoryImportRpcLastRequest = null;
+
+  await page.route("**/auth/v1/user", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(buildLegacyHistoryImportAuthUser()),
+    });
+  });
+
+  await page.route("**/rest/v1/rpc/import_legacy_history", async (route) => {
+    const request = route.request();
+    const body = request.postDataJSON() as ImportLegacyHistoryRpcRequest;
+
+    legacyHistoryImportRpcCallCount += 1;
+    legacyHistoryImportRpcLastRequest = body;
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(buildLegacyHistoryImportResponse(body)),
+    });
+  });
+};
+
+export const expectLegacyHistoryImportToRemainDisabled = async (page: Page) => {
+  const importButton = page.getByTestId("LegacyHistoryImportButton");
+
+  await expect(importButton).toHaveAttribute("aria-disabled", "true");
+  await expect(importButton).toContainText("Import Complete");
+};
+
+export const seedLegacyHistoryImportState = async (page: Page) => {
+  const persistedState = buildLegacyHistoryImportPersistedState(
+    createLegacyHistoryImportSessions(),
+  );
+  const authSession = buildLegacyHistoryImportAuthSession();
+
+  await page.evaluate(
+    ({ storageKey, state, authStorageKey, session }) => {
+      globalThis.localStorage.setItem(
+        storageKey,
+        JSON.stringify({ state, version: 0 }),
+      );
+      globalThis.localStorage.setItem(authStorageKey, JSON.stringify(session));
+    },
+    {
+      storageKey: PERSISTED_STORE_KEY,
+      state: persistedState.state,
+      authStorageKey: LEGACY_HISTORY_IMPORT_AUTH_STORAGE_KEY,
+      session: authSession,
+    },
+  );
+
+  await page.reload();
+  await waitForBrowserFlowReady(page);
 };

--- a/e2e/steps/legacy-history-import.steps.ts
+++ b/e2e/steps/legacy-history-import.steps.ts
@@ -1,0 +1,91 @@
+import { expect } from "@playwright/test";
+import { createBdd } from "playwright-bdd";
+
+import {
+  expectLegacyHistoryImportToRemainDisabled,
+  getLegacyHistoryImportRpcCallCount,
+  getLegacyHistoryImportRpcLastRequest,
+  mockLegacyHistoryImportServices,
+  seedLegacyHistoryImportState,
+  waitForBrowserFlowReady,
+} from "./browser-flow.helpers";
+
+const { Given, When, Then } = createBdd();
+
+Given("the Supabase import service is mocked", async ({ page }) => {
+  await mockLegacyHistoryImportServices(page);
+});
+
+Given(
+  "the user has a signed-in legacy history ready for import",
+  async ({ page }) => {
+    await seedLegacyHistoryImportState(page);
+  },
+);
+
+When("the user starts the legacy history import", async ({ page }) => {
+  const importButton = page.getByTestId("LegacyHistoryImportButton");
+
+  await expect(importButton).toBeEnabled();
+  await importButton.click();
+});
+
+Then("the claimant picker should be visible", async ({ page }) => {
+  const modal = page.getByTestId("LegacyHistoryImportClaimantModal");
+
+  await expect(modal).toBeVisible();
+  await expect(
+    modal.getByText("Choose Your Player", { exact: true }),
+  ).toBeVisible();
+});
+
+When(
+  "the user selects the {string} claimant",
+  async ({ page }, claimantName: string) => {
+    const modal = page.getByTestId("LegacyHistoryImportClaimantModal");
+
+    await modal.getByText(claimantName, { exact: true }).click();
+    await waitForBrowserFlowReady(page, [
+      "Import completed successfully. Imported 2, skipped 0, failed 0.",
+    ]);
+  },
+);
+
+Then("the import completion summary should be visible", async ({ page }) => {
+  await expect(
+    page.getByText(
+      "Import completed successfully. Imported 2, skipped 0, failed 0.",
+      { exact: true },
+    ),
+  ).toBeVisible();
+});
+
+Then(
+  "the import request should preserve guest participant snapshots",
+  async () => {
+    const request = getLegacyHistoryImportRpcLastRequest();
+
+    expect(request).not.toBeNull();
+    expect(request?.sessions).toHaveLength(2);
+    expect(
+      request?.sessions.map((session) =>
+        session.guestParticipants.map((participant) => participant.id),
+      ),
+    ).toEqual([["jordan-session-a"], ["jordan-session-b"]]);
+  },
+);
+
+When(
+  "the user tries to start the legacy history import again",
+  async ({ page }) => {
+    await expectLegacyHistoryImportToRemainDisabled(page);
+  },
+);
+
+Then("the import action should remain disabled", async ({ page }) => {
+  await expectLegacyHistoryImportToRemainDisabled(page);
+});
+
+Then("the import RPC should only be called once", async () => {
+  expect(getLegacyHistoryImportRpcCallCount()).toBe(1);
+});

--- a/hooks/useLegacyHistoryImport.ts
+++ b/hooks/useLegacyHistoryImport.ts
@@ -1,0 +1,293 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { useGameStore } from "../store/store";
+import type {
+  ImportLegacyHistoryRpcRequest,
+  ImportLegacyHistoryRpcResponse,
+} from "../types/legacyHistoryImport";
+import {
+  buildLegacyHistoryClaimantOptions,
+  buildLegacyHistoryImportRequest,
+  type LegacyHistoryDerivedClaimantOption,
+} from "../utils/legacyHistoryImport";
+import {
+  getLegacyHistoryImportRpcClient,
+  getSupabaseClient,
+  hasSupabasePublicConfig,
+} from "../utils/supabaseClient";
+
+export type LegacyHistoryImportPhase =
+  | "checking"
+  | "ready"
+  | "importing"
+  | "completed"
+  | "failed";
+
+export interface UseLegacyHistoryImportResult {
+  claimantOptions: LegacyHistoryDerivedClaimantOption[];
+  historySessionCount: number;
+  hasLocalHistory: boolean;
+  isConfigured: boolean;
+  isAuthenticated: boolean;
+  authChecked: boolean;
+  isImporting: boolean;
+  importPhase: LegacyHistoryImportPhase;
+  canStartImport: boolean;
+  canRetryImport: boolean;
+  availabilityReason: string | null;
+  importError: string | null;
+  importResult: ImportLegacyHistoryRpcResponse | null;
+  importHistory: (
+    claimant: LegacyHistoryDerivedClaimantOption,
+  ) => Promise<ImportLegacyHistoryRpcResponse | null>;
+}
+
+const MISSING_HISTORY_MESSAGE = "No local history saved on this device yet.";
+const MISSING_CONFIG_MESSAGE =
+  "Supabase import is not configured for this build.";
+const MISSING_AUTH_MESSAGE = "Sign in to import this history.";
+
+const validateLegacyHistoryImportRequest = (
+  request: ImportLegacyHistoryRpcRequest,
+) => {
+  request.sessions.forEach((session) => {
+    const playerIds = new Set(session.players.map((player) => player.id));
+
+    if (
+      session.guestParticipants.some(
+        (participant) => participant.id === session.claimedLocalParticipantId,
+      )
+    ) {
+      throw new Error(
+        `Claimed participant ${session.claimedLocalParticipantId} cannot be sent as a guest snapshot for source session ${session.sourceLocalSessionId}.`,
+      );
+    }
+
+    session.guestParticipants.forEach((participant) => {
+      if (!playerIds.has(participant.id)) {
+        throw new Error(
+          `Guest participant ${participant.id} is missing from source session ${session.sourceLocalSessionId}.`,
+        );
+      }
+    });
+  });
+};
+
+const getLegacyHistoryImportPhase = ({
+  authChecked,
+  isImporting,
+  hasCompletedImport,
+  hasFailedImport,
+}: {
+  authChecked: boolean;
+  isImporting: boolean;
+  hasCompletedImport: boolean;
+  hasFailedImport: boolean;
+}): LegacyHistoryImportPhase => {
+  if (authChecked === false) {
+    return "checking";
+  }
+
+  if (isImporting) {
+    return "importing";
+  }
+
+  if (hasCompletedImport) {
+    return "completed";
+  }
+
+  if (hasFailedImport) {
+    return "failed";
+  }
+
+  return "ready";
+};
+
+const getLegacyHistoryImportAvailabilityReason = ({
+  hasLocalHistory,
+  isConfigured,
+  authChecked,
+  isAuthenticated,
+  importPhase,
+}: {
+  hasLocalHistory: boolean;
+  isConfigured: boolean;
+  authChecked: boolean;
+  isAuthenticated: boolean;
+  importPhase: LegacyHistoryImportPhase;
+}): string | null => {
+  if (hasLocalHistory === false) {
+    return MISSING_HISTORY_MESSAGE;
+  }
+
+  if (isConfigured === false) {
+    return MISSING_CONFIG_MESSAGE;
+  }
+
+  if (authChecked && isAuthenticated === false && importPhase !== "completed") {
+    return MISSING_AUTH_MESSAGE;
+  }
+
+  return null;
+};
+
+export const useLegacyHistoryImport = (): UseLegacyHistoryImportResult => {
+  const history = useGameStore((state) => state.history);
+  const claimantOptions = buildLegacyHistoryClaimantOptions(history);
+  const historySessionCount = history.length;
+  const hasLocalHistory = historySessionCount > 0;
+  const isConfigured = hasSupabasePublicConfig();
+
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [authChecked, setAuthChecked] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [importResult, setImportResult] =
+    useState<ImportLegacyHistoryRpcResponse | null>(null);
+
+  const hasCompletedImport = importResult?.importState === "completed";
+  const hasFailedImport =
+    importResult?.importState === "failed" || Boolean(importError);
+
+  const importPhase = getLegacyHistoryImportPhase({
+    authChecked,
+    isImporting,
+    hasCompletedImport,
+    hasFailedImport,
+  });
+
+  const canStartImport =
+    hasLocalHistory &&
+    isConfigured &&
+    authChecked &&
+    isAuthenticated &&
+    claimantOptions.length > 0 &&
+    isImporting === false &&
+    importPhase !== "completed";
+
+  const canRetryImport = canStartImport && importPhase === "failed";
+
+  const refreshAuthenticationState = useCallback(async () => {
+    if (!isConfigured) {
+      setIsAuthenticated(false);
+      setAuthChecked(true);
+      return null;
+    }
+
+    try {
+      const { data, error } = await getSupabaseClient().auth.getUser();
+
+      if (error || !data.user) {
+        setIsAuthenticated(false);
+        setAuthChecked(true);
+        return null;
+      }
+
+      setIsAuthenticated(true);
+      setAuthChecked(true);
+      return data.user.id;
+    } catch {
+      setIsAuthenticated(false);
+      setAuthChecked(true);
+      return null;
+    }
+  }, [isConfigured]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const checkAuthenticationState = async () => {
+      const userId = await refreshAuthenticationState();
+
+      if (!isMounted && userId) {
+        setIsAuthenticated(false);
+      }
+    };
+
+    void checkAuthenticationState();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [refreshAuthenticationState]);
+
+  const importHistory = async (
+    claimant: LegacyHistoryDerivedClaimantOption,
+  ) => {
+    if (importPhase === "completed" && importResult) {
+      return importResult;
+    }
+
+    if (!hasLocalHistory) {
+      setImportError(MISSING_HISTORY_MESSAGE);
+      return null;
+    }
+
+    if (!isConfigured) {
+      setImportError(MISSING_CONFIG_MESSAGE);
+      return null;
+    }
+
+    const userId = await refreshAuthenticationState();
+
+    if (!userId) {
+      setImportError(MISSING_AUTH_MESSAGE);
+      return null;
+    }
+
+    setIsImporting(true);
+    setImportError(null);
+    if (importPhase !== "completed") {
+      setImportResult(null);
+    }
+
+    try {
+      const request = buildLegacyHistoryImportRequest({
+        sessions: history,
+        claimant,
+      });
+
+      validateLegacyHistoryImportRequest(request);
+
+      const response =
+        await getLegacyHistoryImportRpcClient().importLegacyHistory(request);
+
+      setImportResult(response);
+      return response;
+    } catch (error) {
+      setImportError(
+        error instanceof Error
+          ? error.message
+          : "Legacy history import failed.",
+      );
+      return null;
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
+  const availabilityReason = getLegacyHistoryImportAvailabilityReason({
+    hasLocalHistory,
+    isConfigured,
+    authChecked,
+    isAuthenticated,
+    importPhase,
+  });
+
+  return {
+    claimantOptions,
+    historySessionCount,
+    hasLocalHistory,
+    isConfigured,
+    isAuthenticated,
+    authChecked,
+    isImporting,
+    importPhase,
+    canStartImport,
+    canRetryImport,
+    availabilityReason,
+    importError,
+    importResult,
+    importHistory,
+  };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@react-native-community/datetimepicker": "^8.2.0",
         "@react-navigation/bottom-tabs": "^7.2.0",
         "@react-navigation/native": "^7.0.14",
+        "@supabase/supabase-js": "^2.105.4",
         "axios": "^1.12.0",
         "dayjs": "^1.11.13",
         "expo": "~52.0.46",
@@ -5252,6 +5253,90 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.4.tgz",
+      "integrity": "sha512-Ejfa37M5xoIwoxVebxRahnwubPo8g22qkXQ4p50+N9MIvU9UZoN+A8dwVPtczzGf8oV/YXN80ZPxK4aWXuSN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.105.4.tgz",
+      "integrity": "sha512-JVNKbBft3Qkja+WlGaE026AJ2AH9K0UTsxsfvEIHgd4zFrBor4BYRCrYFrv9IDsvVqkF72wKDsODJl5GY/C4tA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.2.tgz",
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.4.tgz",
+      "integrity": "sha512-SppIyLo/kTwIlz1qpv2HN1EQqBg0GVktrDDFsXygYROha3MgVn4rT7p5EjFHFqXQm2rdRGb/BI7bc+jr10m91w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.105.4.tgz",
+      "integrity": "sha512-6ov6c59+8D9h7q4M4Gy/uDJlC0Akxl9/714Y+6vJ+Sijuc16TS/p5DwhfRCLNcIhNiej1gEt+CQUwsjiPt4PxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.105.4.tgz",
+      "integrity": "sha512-Jx+pzMP1Whjof2PWHoVBUA75/p7PQE9CqKBzn1oXVyJDOggMLSH2OzVWwsXYaxEpdC1K/KltwmOX44nL3LHl9g==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.105.4.tgz",
+      "integrity": "sha512-cEnx+k49knU+qdIP7rXwR6fqEXPHZs+74xFK1R0S8MgQ7v9tbePVdGxvO03n3bPympMdJWVLadARBfU4TgNHCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.105.4",
+        "@supabase/functions-js": "2.105.4",
+        "@supabase/postgrest-js": "2.105.4",
+        "@supabase/realtime-js": "2.105.4",
+        "@supabase/storage-js": "2.105.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@tamagui/accordion": {
@@ -13619,6 +13704,15 @@
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@react-native-community/datetimepicker": "^8.2.0",
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",
+    "@supabase/supabase-js": "^2.105.4",
     "axios": "^1.12.0",
     "dayjs": "^1.11.13",
     "expo": "~52.0.46",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,11 @@
 import { defineConfig, devices } from "@playwright/test";
 import { defineBddConfig } from "playwright-bdd";
 import {
+  LEGACY_HISTORY_IMPORT_ANON_KEY,
+  LEGACY_HISTORY_IMPORT_PUBLISHABLE_KEY,
+  LEGACY_HISTORY_IMPORT_SUPABASE_URL,
+} from "./e2e/steps/browser-flow.helpers";
+import {
   DESKTOP_WIDE_VIEWPORT,
   PHONE_SIZED_VIEWPORT,
 } from "./e2e/steps/fixtures";
@@ -43,5 +48,16 @@ export default defineConfig({
     command: `npx expo start --web --port ${webPort}`,
     port: webPort,
     reuseExistingServer: true,
+    env: {
+      EXPO_PUBLIC_SUPABASE_URL:
+        process.env.EXPO_PUBLIC_SUPABASE_URL ??
+        LEGACY_HISTORY_IMPORT_SUPABASE_URL,
+      EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY:
+        process.env.EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY ??
+        LEGACY_HISTORY_IMPORT_PUBLISHABLE_KEY,
+      EXPO_PUBLIC_SUPABASE_ANON_KEY:
+        process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ??
+        LEGACY_HISTORY_IMPORT_ANON_KEY,
+    },
   },
 });

--- a/specs/010-local-cloud-import/checklists/requirements.md
+++ b/specs/010-local-cloud-import/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: One-Time Local-to-Cloud Import
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- Validation reviewed the legacy local-history import flow, duplicate-import handling, and guest-preservation scope

--- a/specs/010-local-cloud-import/contracts/legacy-history-import-contract.md
+++ b/specs/010-local-cloud-import/contracts/legacy-history-import-contract.md
@@ -1,0 +1,103 @@
+# Legacy History Import Contract
+
+## Purpose
+
+This contract defines the public boundary for the one-time local-to-cloud import. The client does not write directly to the gameplay tables. It sends a normalized legacy-session payload to a Supabase RPC, and the RPC creates or skips the canonical cloud rows while recording import state in a private ledger.
+
+## Public Entry Point
+
+### `import_legacy_history`
+
+The feature exposes a single RPC-style write path.
+
+**Caller**: authenticated registered user
+**Schema boundary**: public wrapper function that delegates to private import helpers
+**Trust boundary**: the server validates the account, claimant, fingerprints, and session writes
+
+## Request Shape
+
+```json
+{
+  "claimedLocalParticipantId": "local-player-123",
+  "sessions": [
+    {
+      "sourceLocalSessionId": "1694529378123",
+      "savedAt": "2026-05-01T18:25:43.511Z",
+      "claimedLocalParticipantId": "local-player-123",
+      "commonMatchId": "match-1",
+      "matchesPerPlayer": 3,
+      "players": [
+        { "id": "local-player-123", "name": "Sam", "drinksTaken": 4 },
+        { "id": "local-player-456", "name": "Jordan", "drinksTaken": 2 }
+      ],
+      "guestParticipants": [
+        { "id": "local-player-456", "name": "Jordan", "drinksTaken": 2 }
+      ],
+      "matches": [
+        {
+          "id": "match-1",
+          "homeTeam": "Team A",
+          "awayTeam": "Team B",
+          "homeGoals": 2,
+          "awayGoals": 1,
+          "startTime": "2026-05-01T18:30:00.000Z"
+        }
+      ],
+      "playerAssignments": {
+        "local-player-123": ["match-1"],
+        "local-player-456": ["match-1"]
+      }
+    }
+  ]
+}
+```
+
+## Response Shape
+
+```json
+{
+  "accountId": "uuid",
+  "importState": "in_progress",
+  "claimedLocalParticipantId": "local-player-123",
+  "summary": {
+    "importedCount": 1,
+    "skippedCount": 0,
+    "failedCount": 0
+  },
+  "sessions": [
+    {
+      "sourceLocalSessionId": "1694529378123",
+      "sourceFingerprint": "sha256:...",
+      "state": "imported",
+      "cloudSessionId": "uuid"
+    }
+  ]
+}
+```
+
+## Behavioral Rules
+
+- The caller must be authenticated.
+- The claimant must be one participant from the submitted payload.
+- The RPC must compute a deterministic source fingerprint server-side from the normalized session payload.
+- A matching `(account_id, source_fingerprint)` row must be treated as already imported.
+- A completed account import must no-op or return already-imported status on later runs.
+- Partial failures must not roll back successful sessions in the same batch.
+- Guest participants should be carried in the request as session-scoped snapshots and remain non-claimable.
+- Guest participants must remain session-scoped and must not be promoted into durable account records.
+
+## Error / Status Semantics
+
+| State         | Meaning                                                                |
+| ------------- | ---------------------------------------------------------------------- |
+| `in_progress` | Import has begun and at least one session is still eligible to process |
+| `imported`    | A source session was written into the canonical cloud tables           |
+| `skipped`     | The same source fingerprint was already recorded for this account      |
+| `failed`      | The session could not be normalized or written                         |
+| `conflict`    | The payload conflicts with existing claimant or fingerprint state      |
+
+## Notes for Client Integration
+
+- The Settings screen should show claimant selection before the RPC call starts.
+- The client should persist no secret import marker of its own; the server ledger is authoritative.
+- The response should be used to show per-session status and whether the account import is already complete.

--- a/specs/010-local-cloud-import/data-model.md
+++ b/specs/010-local-cloud-import/data-model.md
@@ -1,0 +1,167 @@
+# Data Model: One-Time Local-to-Cloud Import
+
+## Overview
+
+This feature adds an import control plane around the existing cloud gameplay tables. It does not introduce a second gameplay model. Instead, it records import progress in private ledger tables, then writes imported sessions into the existing canonical session, participant, match, assignment, and event tables so the current history and leaderboard read models can consume them unchanged.
+
+The key new concepts are:
+
+- a signed-in account can have at most one completed import state;
+- each source legacy session is identified by a deterministic fingerprint;
+- the user explicitly chooses one local participant to represent the signed-in account;
+- guest participants remain session-scoped and are never promoted into permanent identities.
+
+## Enumerations
+
+### `legacy_history_import_state`
+
+- `in_progress`
+- `completed`
+- `failed`
+
+### `legacy_history_import_session_state`
+
+- `pending`
+- `imported`
+- `skipped`
+- `failed`
+- `conflict`
+
+## Physical Entities
+
+### Legacy History Import State
+
+One row per signed-in account that tracks the claimant choice and whether the account has already finished its one-time import.
+
+| Field                            | Type                          | Notes                                                    |
+| -------------------------------- | ----------------------------- | -------------------------------------------------------- |
+| `account_id`                     | `uuid`                        | Primary key and FK to `public.accounts.id`               |
+| `claimed_local_participant_id`   | `text`                        | Stable local participant id selected by the user         |
+| `claimed_local_participant_name` | `text`                        | Display name captured for audit and conflict checks      |
+| `state`                          | `legacy_history_import_state` | Current account-level import state                       |
+| `started_at`                     | `timestamptz`                 | When the first import attempt began                      |
+| `completed_at`                   | `timestamptz`                 | Set when all eligible sessions are imported successfully |
+| `failed_at`                      | `timestamptz`                 | Set when a batch ends in failure                         |
+| `last_error`                     | `text`                        | Human-readable failure summary                           |
+| `created_at`                     | `timestamptz`                 | Default `now()`                                          |
+| `updated_at`                     | `timestamptz`                 | Default `now()`                                          |
+
+**Relationships**
+
+- One account has zero or one import-state row.
+- The row gates whether later runs should no-op after completion.
+
+**Validation rules**
+
+- `state = completed` implies `completed_at` is not null.
+- `state = failed` implies `failed_at` is not null.
+- `claimed_local_participant_id` must remain stable for the lifetime of the import state.
+
+### Legacy History Import Session
+
+One row per legacy session fingerprint per account. This is the durable dedupe ledger for retries and cross-device repeats.
+
+| Field                          | Type                                  | Notes                                                                        |
+| ------------------------------ | ------------------------------------- | ---------------------------------------------------------------------------- |
+| `id`                           | `uuid`                                | Primary key                                                                  |
+| `account_id`                   | `uuid`                                | FK to `public.accounts.id`                                                   |
+| `source_fingerprint`           | `text`                                | Deterministic hash of the normalized legacy session snapshot                 |
+| `source_local_session_id`      | `text`                                | Local session id from AsyncStorage history                                   |
+| `claimed_local_participant_id` | `text`                                | The local participant that represented the imported account for this session |
+| `cloud_session_id`             | `uuid`                                | Nullable FK to `public.game_sessions.id` after a successful write            |
+| `state`                        | `legacy_history_import_session_state` | Per-session import status                                                    |
+| `error_message`                | `text`                                | Failure detail for UI/status reporting                                       |
+| `created_at`                   | `timestamptz`                         | Default `now()`                                                              |
+| `updated_at`                   | `timestamptz`                         | Default `now()`                                                              |
+
+**Relationships**
+
+- One imported legacy session maps to zero or one canonical cloud session.
+- One account can have many source-fingerprint rows.
+- The unique `(account_id, source_fingerprint)` pair prevents duplicate imports of the same source session.
+
+**Validation rules**
+
+- The same source fingerprint cannot be inserted twice for the same account.
+- `state = imported` implies `cloud_session_id` is not null.
+- `state = failed` implies `error_message` is not null.
+
+### Legacy Session Payload
+
+The RPC accepts a normalized session payload, not a raw local database dump.
+
+| Field                          | Type             | Notes                                                           |
+| ------------------------------ | ---------------- | --------------------------------------------------------------- |
+| `source_local_session_id`      | `text`           | Legacy local `GameSession.id` from AsyncStorage                 |
+| `saved_at`                     | `timestamptz`    | Local session timestamp                                         |
+| `claimed_local_participant_id` | `text`           | User-selected claimant for the signed-in account                |
+| `players`                      | `jsonb`          | Ordered local player snapshot                                   |
+| `guestParticipants`            | `jsonb`          | Session-scoped guest snapshots preserved in the request payload |
+| `matches`                      | `jsonb`          | Ordered local match snapshot                                    |
+| `player_assignments`           | `jsonb`          | Local player-to-match assignment map                            |
+| `common_match_id`              | `text` \| `null` | Local common match id                                           |
+| `matches_per_player`           | `integer`        | Local setup summary                                             |
+
+**Relationships**
+
+- The server computes `source_fingerprint` from the normalized payload.
+- The chosen claimant is stored separately from the fingerprint.
+- Guest participant snapshots are carried separately in the payload so non-claimed players stay session-scoped.
+
+## Logical Entities
+
+### Source Fingerprint
+
+- Deterministic hash of the normalized legacy session snapshot.
+- Independent of retry attempts and independent of which device sent the payload.
+- Used to dedupe the same source session across repeated imports.
+
+### Claimed Local Participant
+
+- The local player selected by the user to represent the signed-in account.
+- Becomes the registered participant row in the imported cloud session.
+- Must not be inferred automatically from display-name matching.
+
+### Import State
+
+- Account-level completion marker for the one-time import.
+- The UI should show this as `in_progress`, `completed`, or `failed`.
+- Once `completed`, later calls for that account should no-op or return an already-imported response.
+
+## Relationship Summary
+
+- `public.accounts` 1:0..1 `private.legacy_history_import_state`
+- `public.accounts` 1:\* `private.legacy_history_import_sessions`
+- `private.legacy_history_import_sessions.source_fingerprint` uniquely identifies a source session per account
+- `private.legacy_history_import_sessions.cloud_session_id` points to the canonical imported `public.game_sessions` row
+- Imported canonical sessions still use `public.participants`, `public.matches`, `public.assignments`, and `public.gameplay_events`
+
+## State Transitions
+
+### Account import lifecycle
+
+```text
+not started -> in_progress -> completed
+                    \-> failed
+```
+
+- The import is complete only when all eligible source sessions have been processed.
+- After completion, subsequent imports for the same account should return already-imported status.
+
+### Session import lifecycle
+
+```text
+pending -> imported
+       \-> skipped
+       \-> failed
+       \-> conflict
+```
+
+- `skipped` means the server recognized an already-imported source fingerprint.
+- `conflict` means the same fingerprint was attempted with incompatible claimant data or malformed payload contents.
+
+## Database Invariants
+
+- The same source fingerprint cannot be imported twice for the same account.
+- A completed account import is terminal for that account in v1.
+- Guest participants remain session-scoped rows in the canonical cloud session tables.

--- a/specs/010-local-cloud-import/plan.md
+++ b/specs/010-local-cloud-import/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan: One-Time Local-to-Cloud Import
+
+**Branch**: `127-us24-add-one-time-local-to-cloud-import-for-existing-registered-users` | **Date**: 2026-05-09 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from [spec.md](spec.md)
+
+## Summary
+
+Build a one-time import pipeline for signed-in users that reads legacy AsyncStorage history, asks the user to choose one local participant to claim as their account, sends a normalized session batch to a secure Supabase RPC, and writes imported sessions into the existing cloud tables while recording account-level completion and per-session fingerprints in a private import ledger. The Settings screen exposes progress, retry, and already-imported states; the cloud path guarantees idempotency and guest-preserving session snapshots.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.3.3 in Expo SDK 52 / React Native 0.76.9 / React 18.3.1
+**Primary Dependencies**: Expo Router 4, Zustand 5, AsyncStorage, `react-native-toast-message`, `@supabase/supabase-js`, Supabase Auth/Postgres local stack, Supabase CLI, pgTAP, `playwright-bdd`, `@playwright/test`
+**Storage**: Existing AsyncStorage history snapshot plus new private Supabase import ledger tables; imported sessions land in current `public.game_sessions`, `participants`, `matches`, `assignments`, and `gameplay_events`
+**Testing**: `npm run db:reset`, `npm run db:test`, Jest/RNTL unit coverage for the Settings import flow and claimant selection, Playwright BDD web E2E for the full import journey, `npm run lint`
+**Applicable Skills**: `supabase`, `supabase-postgres-best-practices`, `database-testing`, `react-native-testing`
+**Tooling Preference**: Use the Supabase MCP/CLI path for schema inspection and local validation; keep privileged import code in the private schema and expose only a minimal public RPC wrapper
+**Target Platform**: Cross-platform Expo app on native and web backed by local Supabase/Postgres during development
+**Project Type**: Cross-platform mobile/web application with a first-party Supabase database workspace
+**Performance Goals**: Per-session fingerprint lookups and completed-import checks should be index-backed; the import RPC should process batches without blocking the Settings UI longer than necessary and should surface partial results quickly enough for retry UX
+**Constraints**: No new custom backend; no direct client writes to protected session tables; preserve the original local history; keep guest participants session-scoped; make the import one-time per account with server-side dedupe; do not store the privileged import helper in an exposed schema
+**Scale/Scope**: One new Settings entry point, one secure import RPC surface, one or two private import ledger tables, a handful of database tests, and one browser E2E flow
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+- PASS: Cross-platform behavior is defined in the spec for native and web, and the new Settings journey applies to both.
+- PASS: Shared-state writes are server-authoritative through a secure Supabase RPC plus a private import ledger, with explicit idempotency and conflict handling.
+- PASS: The existing event-backed gameplay history remains canonical; the import only hydrates normal session tables and preserves guest session scope.
+- PASS: The work is sliced into independently testable user stories with Gherkin acceptance criteria and explicit edge cases.
+- PASS: The test plan includes unit coverage for claimant selection and import status, database coverage for ledger and RPC behavior, and end-to-end coverage for the new Settings journey.
+- PASS: Applicable skills were identified before planning began and directly informed the schema, security, and testing choices.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-local-cloud-import/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── legacy-history-import-contract.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+app/
+├── _layout.tsx
+├── userPreferences.tsx
+└── style/
+
+components/
+├── preferences/
+│   ├── AppearanceSettings.tsx
+│   ├── LeagueSettings.tsx
+│   ├── SoundNotificationSettings.tsx
+│   └── ...
+├── history/
+└── ui/
+
+hooks/
+├── useGameProgressController.ts
+└── useLegacyHistoryImport.ts   # new
+
+store/
+└── store.ts
+
+supabase/
+├── config.toml
+├── migrations/
+└── tests/
+    └── database/
+
+e2e/
+├── features/
+└── steps/
+
+tests/
+├── app/
+└── components/
+```
+
+**Structure Decision**: Keep the feature inside the existing Expo app and Supabase workspace. Client work lands in the Settings screen, a claimant-selection import hook, and a small Supabase client/service module. Database work lands in private import-ledger migrations and pgTAP tests; web journey coverage uses the existing Playwright BDD setup.
+
+## Phase 0 Output
+
+- `research.md` resolves the private import ledger vs client-only marker decision, the secure RPC wrapper vs Edge Function tradeoff, the claimant-selection flow, the server-computed source fingerprint, and the completion gate for repeat imports.
+- The research also records that the Supabase changelog currently shows no blocking function/RLS breaking changes for this slice, but any new public database object would need explicit grants because Supabase no longer auto-exposes new public tables.
+
+## Phase 1 Output
+
+- `data-model.md` defines the import-state tables, source fingerprint semantics, claimant mapping, and per-session status model.
+- `contracts/legacy-history-import-contract.md` documents the RPC payload and result shape for the client/server boundary.
+- `quickstart.md` documents the Supabase CLI workflow, claimant-selection smoke check, and validation commands for database, unit, and E2E coverage.
+- The copilot agent context is refreshed after the design artifacts are written.
+
+## Post-Design Constitution Check
+
+- PASS: The design keeps the new journey cross-platform and explicitly scoped to Settings on native and web.
+- PASS: The design keeps the server authoritative by routing writes through a secure RPC and a private ledger instead of direct client writes.
+- PASS: The event-backed gameplay model remains unchanged; the import only hydrates canonical session tables.
+- PASS: The verification plan covers the new UI flow, the import ledger, and the secure RPC contract at the right test layers.
+- PASS: Applicable skills and the Supabase security guidance remain explicit throughout the plan.
+
+## Complexity Tracking
+
+No constitution violations or exceptional complexity adjustments were required.

--- a/specs/010-local-cloud-import/quickstart.md
+++ b/specs/010-local-cloud-import/quickstart.md
@@ -1,0 +1,116 @@
+# Quickstart: One-Time Local-to-Cloud Import
+
+## Purpose
+
+This quickstart covers how to build and verify the one-time local-to-cloud import feature without mixing it into the unrelated gameplay or read-model flows.
+
+## Prerequisites
+
+- Docker Desktop or another supported local container runtime
+- Node.js and npm used by this repo
+- Supabase CLI available through `npx`
+- Repository root at `C:\src\dong`
+
+## Initial Setup
+
+1. Start the local Supabase stack.
+
+```powershell
+npm run db:start
+```
+
+2. Confirm the local database and auth services are healthy.
+
+```powershell
+npm run db:status
+```
+
+## Implementation Order
+
+1. Create a migration scaffold for the import ledger and RPC.
+
+```powershell
+npx --yes supabase migration new add_legacy_history_import
+```
+
+2. Implement the database changes in this order:
+
+- private import-state tables and enums
+- source fingerprint helper(s)
+- private import processing helper
+- public RPC wrapper with explicit grants
+- supporting indexes for `account_id`, `source_fingerprint`, and cloud session lookups
+
+3. Add database tests under `supabase/tests/database/`.
+
+Recommended initial files:
+
+- `120_legacy_history_import_schema.test.sql`
+- `130_legacy_history_import_dedupe.test.sql`
+- `140_legacy_history_import_claim.test.sql`
+- `150_legacy_history_import_retry.test.sql`
+
+## Authenticated User Testing
+
+Use pgTAP fixtures inside rolled-back transactions to seed `auth.users` rows and matching `public.accounts` rows. The import contract depends on the signed-in account id and the chosen local claimant, so the database tests should build both fixtures explicitly.
+
+Avoid browser login flows for database validation. The core correctness risks are the private import ledger, per-session fingerprint dedupe, and completion gating.
+
+## Verification Workflow
+
+1. Reset the local database so migrations apply from scratch.
+
+```powershell
+npm run db:reset
+```
+
+2. Run the database tests.
+
+```powershell
+npm run db:test
+```
+
+3. Run the focused unit tests for the Settings import flow and claimant selection.
+
+```powershell
+npx jest --runInBand <focused-test-file-or-pattern>
+```
+
+Use `npx jest` for one-shot runs; the repo's `npm test` script is watch mode.
+
+4. Run the web end-to-end import journey.
+
+```powershell
+npm run test:e2e
+```
+
+The repo's Playwright BDD config already covers both desktop and phone viewports. Keep the feature flow in the main BDD config rather than moving it into the standalone home-shell config.
+
+5. If repository metadata or developer guidance changed, run lint as the final repo-level check.
+
+```powershell
+npm run lint
+```
+
+## Smoke Checklist
+
+- The Settings screen exposes claimant selection before import starts.
+- The RPC returns per-session imported, skipped, failed, or conflict status.
+- Guest participants remain session-scoped in the request payload and in the imported cloud sessions.
+- Re-running the same import after completion no-ops or reports already imported.
+- Imported sessions appear in the current cloud-backed history screens without extra client-side aggregation.
+
+## Out of Scope For This Story
+
+- Any new gameplay rules or read-model changes
+- A custom backend outside Supabase
+- Automatic cross-device syncing of live local and cloud state
+- Guest identity promotion into durable registered accounts
+
+## Shutdown
+
+When you are done with local database work:
+
+```powershell
+npm run db:stop
+```

--- a/specs/010-local-cloud-import/research.md
+++ b/specs/010-local-cloud-import/research.md
@@ -1,0 +1,84 @@
+# Research: One-Time Local-to-Cloud Import
+
+## Decision 1: Store import state in a private Supabase ledger instead of a client-only marker
+
+**Decision**: Add private import ledger tables in Supabase Postgres to record account-level completion and per-session source fingerprints.
+
+**Rationale**: The import has to survive retries, partial failures, and cross-device repeats. A client-side flag would be easy to lose, while a private ledger gives the server a durable source of truth without exposing extra tables through the Data API.
+
+**Alternatives considered**:
+
+- A local AsyncStorage marker only: rejected because it disappears with app reinstall, device migration, or a second device.
+- A public table in `public`: rejected because this creates an unnecessary exposed surface and requires extra RLS/grant work for metadata that the client never needs to read directly.
+- No ledger at all: rejected because per-session retries and once-per-account completion would be impossible to enforce safely.
+
+## Decision 2: Use a secure RPC wrapper that calls a private helper, not an Edge Function
+
+**Decision**: Expose a minimal public RPC that invokes private import helpers in the `private` schema.
+
+**Rationale**: This feature is data-heavy and needs to create the cloud session graph, ledger rows, and error metadata atomically. A database function can validate the payload, compute fingerprints, and insert the imported sessions in one boundary without introducing a separate backend or network hop.
+
+**Alternatives considered**:
+
+- An Edge Function: rejected because it adds infrastructure and still needs the database for the actual writes and dedupe ledger.
+- Direct client inserts into `public` tables: rejected because the client would have to bypass or duplicate the import validation logic and would not be able to enforce one-time completion safely.
+- A new custom API service: rejected because the repo already standardizes on Supabase for this kind of server-authoritative workflow.
+
+## Decision 3: Let the user choose one local participant to represent the imported account
+
+**Decision**: Ask the user once, at import start, to choose which legacy local participant represents the signed-in account.
+
+**Rationale**: The local snapshot has names and scores but no durable account identity. Exact-name matching is ambiguous, and guessing would make it easy to attach the wrong history to the signed-in account. A single explicit claimant selection keeps the import understandable and audit-friendly.
+
+**Alternatives considered**:
+
+- Match by display name automatically: rejected because duplicate names are common and mutable.
+- Use the first local participant: rejected because the ordering is not a reliable identity signal.
+- Import every player as a guest: rejected because the signed-in account would never get a durable identity row in the imported sessions.
+
+## Decision 4: Compute the source fingerprint server-side from a canonical normalized session snapshot
+
+**Decision**: The RPC will canonicalize each legacy session snapshot and compute a deterministic fingerprint in the database.
+
+**Rationale**: The server should own dedupe semantics. Server-side fingerprinting avoids trusting the client to create uniqueness correctly and makes retries deterministic even if the payload is re-sent from another device.
+
+**Alternatives considered**:
+
+- Client-computed hash only: rejected because the server would still need to trust the client for uniqueness.
+- Batch-level import IDs only: rejected because a batch ID can mark a retry, but it cannot uniquely identify the source session being imported.
+- Fingerprint derived from the claimant choice: rejected because the same source session must remain dedupable even if the claimant selection changes or is retried incorrectly.
+
+## Decision 5: Gate repeat runs by account completion but keep per-session dedupe until the account is completed
+
+**Decision**: Record account-level import status and let per-session fingerprint rows dedupe retries, while treating a completed account import as terminal.
+
+**Rationale**: The clarified story says the import is one-time for the account, but it also needs partial failures and retry behavior. The cleanest way to satisfy both is to keep the job retryable until it reaches a completed state, then no-op later runs for the same account.
+
+**Alternatives considered**:
+
+- Always allow re-imports: rejected because it would violate the one-time import requirement.
+- Only allow one session at a time without account completion: rejected because the UX would be confusing and would not provide a clear success boundary.
+- Block partial retries once any session succeeds: rejected because the spec explicitly requires retrying failed sessions without duplicating successful ones.
+
+## Decision 6: Reuse the existing canonical session tables for imported data
+
+**Decision**: Imported sessions will be written into the existing `game_sessions`, `participants`, `matches`, `assignments`, and `gameplay_events` tables.
+
+**Rationale**: The repository already has a mature cloud schema and read models. Reusing those tables means imported history automatically appears in the existing history, comparison, and leaderboard surfaces without a second transformation layer.
+
+**Alternatives considered**:
+
+- A separate import-only mirror of history: rejected because it would duplicate the read-model work and create a second source of truth.
+- Client-only cached summaries: rejected because the imported sessions would never become durable cloud history.
+
+## Decision 7: Validate with database tests, one Settings-flow unit test, and one web E2E path
+
+**Decision**: Use pgTAP to verify the RPC/ledger semantics, Jest + RNTL for the claimant-selection and status UI, and Playwright BDD for the web import journey.
+
+**Rationale**: The highest risk lives in the database contract, but the new UI journey is substantial enough to warrant a single end-to-end test. The repo already has the exact tooling needed for this split.
+
+**Alternatives considered**:
+
+- Manual validation only: rejected because the feature is security- and idempotency-sensitive.
+- E2E-only coverage: rejected because it would miss the database invariants.
+- Database tests only: rejected because the claimant-selection UI is a new user journey.

--- a/specs/010-local-cloud-import/spec.md
+++ b/specs/010-local-cloud-import/spec.md
@@ -1,0 +1,141 @@
+# Feature Specification: One-Time Local-to-Cloud Import
+
+**Feature Branch**: `127-us24-add-one-time-local-to-cloud-import-for-existing-registered-users`
+**Created**: 2026-05-09
+**Status**: Draft
+**Input**: User description: "Plan implementation for issue #127 '[US2.4] Add one-time local-to-cloud import for existing registered users' using parent epic #115 for context."
+
+## Clarifications
+
+### Session 2026-05-09
+
+- Q: Should the one-time import be enforced per registered account or per device history set? → A: Per registered account; once one import succeeds, later imports for that account only dedupe already-imported sessions.
+- Q: How should the importer decide which legacy local participant becomes the signed-in account? → A: Ask the user to pick one local participant once during import, then use that choice to create the registered participant rows.
+- Q: How should duplicate imports be detected for the same legacy local session? → A: Server stores a deterministic fingerprint for each legacy local session and treats matching fingerprints as already imported.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Start Import From Settings (Priority: P1)
+
+As a signed-in registered user with legacy local history on my device, I can start a one-time import from Settings, choose which local participant represents my account, and move my existing local games into the cloud without rebuilding them manually.
+
+**Why this priority**: Without a clear entry point and first successful import, the feature delivers no user value.
+
+**Independent Test**: Sign in, open Settings, run import on a device with legacy local sessions, and confirm the app reports completion and leaves a cloud-backed copy of the sessions.
+
+**Acceptance Scenarios (Gherkin style)**:
+
+1. **Given** a signed-in registered user with eligible local sessions on the device, **When** they start the import flow and choose the local participant that represents their account, **Then** the system begins importing the eligible sessions and shows progress or status.
+2. **Given** a signed-in registered user with no eligible local sessions, **When** they open the import action, **Then** the system shows an empty-state message and performs no cloud writes.
+3. **Given** an import completes successfully, **When** the user returns to the app, **Then** the imported sessions are available through the cloud-backed history source.
+
+---
+
+### User Story 2 - Avoid Duplicate Imports (Priority: P1)
+
+As a signed-in registered user, I can retry the import safely so that an interrupted or repeated run does not create duplicate cloud sessions.
+
+**Why this priority**: Idempotency is required before the feature can be trusted on a flaky network or across multiple devices.
+
+**Independent Test**: Run the same import twice against the same local history dataset and verify cloud session counts do not increase after the first success.
+
+**Acceptance Scenarios (Gherkin style)**:
+
+1. **Given** a local session that was already imported, **When** the import flow runs again, **Then** the existing cloud session is reused and not duplicated.
+2. **Given** a cloud import fails partway through a batch, **When** the user retries, **Then** sessions that already succeeded are not written again.
+3. **Given** the same legacy local dataset is imported from another signed-in device for the same account, **When** the flow runs, **Then** repeated source sessions are still deduplicated.
+
+---
+
+### User Story 3 - Preserve Legacy Guest Participants (Priority: P2)
+
+As a signed-in registered user, I can import sessions that contained non-account players so those players remain session-scoped guest snapshots in the cloud.
+
+**Why this priority**: Preserving guest identity is necessary for history fidelity and for avoiding accidental promotion of temporary players into durable accounts.
+
+**Independent Test**: Import a session with a mix of account-linked and guest-like local players and confirm guest rows remain session-scoped and non-claimable.
+
+**Acceptance Scenarios (Gherkin style)**:
+
+1. **Given** imported sessions include non-account participants, **When** the import completes, **Then** those participants are stored as guest-scoped session identities.
+2. **Given** imported sessions include the same display name as a durable account, **When** the import completes, **Then** the system does not auto-convert that guest into a registered account record.
+3. **Given** a successful import, **When** the user opens history, **Then** guest rows remain visible only inside the imported session they came from.
+
+---
+
+### Edge Cases
+
+- No legacy local history exists on the device.
+- The signed-in account changes while import is in progress.
+- A session was imported successfully but the client never received the success response.
+- A local snapshot is incomplete or corrupted and cannot be translated into a valid cloud session.
+- The same import is started from more than one device for the same signed-in account.
+- The same signed-in account starts import again from another device after a successful import and the flow should no-op or report already imported rather than creating new cloud sessions.
+- The same legacy local session is imported again from a different device or after a retry, but the fingerprint matches an already imported source session.
+- A legacy session contains duplicate names or several guests with the same display name.
+- The user-selected local participant is ambiguous because the same display name appears in multiple legacy sessions or multiple players share the same name within one session.
+- Import succeeds for some sessions and fails for others in the same batch.
+
+## Platform & State Impact _(mandatory when applicable)_
+
+- **Platform Behavior**: The import entry point lives in the signed-in settings experience and must work consistently on native and web. If the user is signed out or has no local history, the import action should degrade to a clear empty or disabled state.
+- **Shared State Model**: Local persisted history remains the source of the legacy dataset until import runs. Once imported, cloud history becomes the durable record for those sessions, and repeated import attempts must be safe to replay.
+- **Shared State Model**: Local persisted history remains the source of the legacy dataset until import runs. Once imported, cloud history becomes the durable record for those sessions, and repeated import attempts must be safe to replay using a deterministic source fingerprint for each legacy local session.
+- **Identity Model**: The signed-in registered account owns the imported sessions. Legacy player rows that do not already map to a durable account remain guest-scoped session members. Import must not create new claimable identities for those guests.
+- **Identity Model**: The signed-in registered account owns the imported sessions and is linked to one user-selected legacy participant from the imported history. Other local player rows remain guest-scoped session members. Import must not create new claimable identities for those guests.
+- **Migration / Backfill**: This is a one-time backfill from existing device-local history into cloud history, not an ongoing sync pipeline. The feature must preserve enough source identity to prevent duplicate imports on later retries.
+- **Migration / Backfill**: This is a one-time backfill from existing device-local history into cloud history, not an ongoing sync pipeline. The import is enforced per registered account, so later attempts from the same account must not create new cloud sessions once the first import has completed.
+
+## Delivery & Automation Impact _(mandatory)_
+
+- **Unit Test Coverage**: Cover the local-session-to-cloud payload mapping, session deduplication, guest preservation, status transitions, and partial retry behavior.
+- **E2E Test Coverage**: Yes. Add a primary end-to-end flow for a signed-in user starting import from Settings, completing it, and then seeing the imported sessions in cloud-backed history.
+- **Applicable Skills**: `supabase`, `supabase-postgres-best-practices`, `database-testing`, `react-native-testing`
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The system MUST allow a signed-in registered user to start a one-time import of legacy local history from an in-app settings surface.
+- **FR-002**: The system MUST translate each eligible local session into a cloud-backed session record that preserves the session date, participants, matches, assignments, common match, and summary totals.
+- **FR-003**: The system MUST keep the importing account as the durable owner of the imported session.
+- **FR-003**: The system MUST let the user choose one legacy local participant to represent the importing registered account and MUST create that participant as the account-linked row during import.
+- **FR-004**: The system MUST preserve non-account local players as guest-scoped session participants during import.
+- **FR-005**: The system MUST ensure that repeated import attempts do not create duplicate cloud sessions for the same legacy source session.
+- **FR-005**: The system MUST ensure that repeated import attempts do not create duplicate cloud sessions for the same legacy source session.
+- **FR-006**: The system MUST report per-session import status so the user can distinguish imported, skipped, and failed sessions.
+- **FR-007**: The system MUST allow failed sessions to be retried without re-importing sessions that already succeeded.
+- **FR-008**: The system MUST make imported sessions visible in cloud-backed history after a successful import.
+- **FR-009**: The system MUST not delete or overwrite the original local history as part of import.
+- **FR-010**: The system MUST not promote guest participants into durable registered-user records during import.
+- **FR-011**: The system MUST treat the import as complete for a registered account after the first successful run and MUST no-op or report already imported on later runs for the same account.
+- **FR-012**: The system MUST store a deterministic source fingerprint for each legacy local session and use that fingerprint to recognize already imported sessions across retries and devices.
+
+### Key Entities _(include if feature involves data)_
+
+- **Legacy Local Session Snapshot**: A completed local game record containing players, matches, assignments, common match, and drink totals.
+- **Import Batch**: One attempt to move a set of local sessions into cloud history for a signed-in account.
+- **Imported Cloud Session**: A cloud-backed session created from a legacy snapshot and visible in history.
+- **Claimed Local Participant**: The legacy local participant the user selects to represent the signed-in account during import.
+- **Source Fingerprint**: The deterministic identifier derived from a legacy local session snapshot that allows the system to recognize the same session on retry or from another device.
+- **Import Status**: The current state of an individual session within an import batch, such as pending, imported, skipped, or failed.
+- **Guest Participant Snapshot**: A local player carried into cloud history as a session-scoped participant without durable account ownership.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: In validation, a signed-in user can complete a typical import flow from Settings in under 2 minutes.
+- **SC-002**: In validation, 100% of eligible local sessions are imported exactly once, even when the import flow is retried.
+- **SC-003**: In validation, re-running the same import on the same dataset creates zero duplicate cloud sessions.
+- **SC-004**: In validation, guest participants remain session-scoped in 100% of imported sessions.
+- **SC-005**: In validation, partial failures are reported per session and successful sessions remain imported after retry.
+
+## Assumptions
+
+- Legacy local history is already present on the device and is the source of truth for the import.
+- The importing signed-in account owns the imported sessions, while non-account local players remain guest-scoped.
+- The importing signed-in account is linked to one user-selected local participant identity during import.
+- The feature is a migration aid, not a permanent two-way sync between local and cloud storage.
+- Cloud-backed history already exists or will exist by the time this feature ships, so imported sessions only need to conform to that contract.
+- Existing local history may remain on device after import until a later cleanup decision.

--- a/specs/010-local-cloud-import/tasks.md
+++ b/specs/010-local-cloud-import/tasks.md
@@ -1,0 +1,191 @@
+---
+description: "Task list template for feature implementation"
+---
+
+# Tasks: One-Time Local-to-Cloud Import
+
+**Input**: Design documents from `/specs/010-local-cloud-import/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: This feature changes shared state, persistence, and a substantial Settings flow, so it includes unit coverage, pgTAP database coverage, and a Playwright BDD journey.
+
+**Organization**: Tasks are grouped by user story so each slice can be implemented and validated independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Install the shared client dependency and define import-domain types used by the hook, utilities, and tests.
+
+- [x] T001 [P] Add `@supabase/supabase-js` to `package.json` and `package-lock.json`
+- [x] T002 [P] Define shared import-domain types and RPC payload/response shapes in `types/legacyHistoryImport.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core database and helper infrastructure that every story depends on.
+
+**⚠️ CRITICAL**: No story work should begin until the private ledger, RPC wrapper, and shared client helpers are in place.
+
+- [x] T003 Create `supabase/migrations/023_legacy_history_import_schema.sql` with private import-state tables, enums, indexes, and grants for account completion and per-session fingerprints
+- [x] T004 [P] Create `utils/supabaseClient.ts` with a typed Supabase client factory that reads the Expo public Supabase env values and exposes the RPC client used by the importer
+- [x] T005 [P] Create `utils/legacyHistoryImport.ts` with shared normalization helpers for local history snapshots, claimant derivation, guest preservation, and source-fingerprint inputs
+
+**Checkpoint**: The database contract and shared helper layer exist, so the Settings flow and tests can be implemented safely.
+
+---
+
+## Phase 3: User Story 1 - Start Import From Settings (Priority: P1) 🎯 MVP
+
+**Goal**: A signed-in user can open Settings, choose the local participant that represents their account, and start the first cloud import run.
+
+**Independent Test**: Sign in, seed legacy local history, open Settings, start import, choose a claimant, and confirm the app reports progress/completion while creating cloud-backed sessions.
+
+### Tests for User Story 1 (REQUIRED coverage) ⚠️
+
+- [x] T006 [P] [US1] Add pgTAP schema coverage in `supabase/tests/database/120_legacy_history_import_schema.test.sql` to verify the private ledger tables, indexes, and public RPC grants exist with the expected shape
+- [x] T007 [P] [US1] Add unit coverage in `__tests__/utils/legacyHistoryImport.test.ts` for claimant normalization, snapshot flattening, and source-fingerprint inputs
+- [x] T008 [P] [US1] Add component-level coverage in `__tests__/components/preferences/LegacyHistoryImport.platform.test.tsx` for claimant selection, empty history, and in-progress rendering
+- [x] T009 [P] [US1] Add screen-level regression coverage in `__tests__/app/userPreferences.platform.test.tsx` to verify the Settings screen renders the new import entry point without breaking the existing shell
+- [x] T010 [P] [US1] Add Playwright BDD coverage in `e2e/features/legacy-history-import.feature`, `e2e/steps/legacy-history-import.steps.ts`, and `e2e/steps/browser-flow.helpers.ts` for starting import from Settings, selecting a claimant, and completing the first successful run
+
+### Implementation for User Story 1
+
+- [x] T011 [P] [US1] Implement `hooks/useLegacyHistoryImport.ts` to read the persisted local history, prepare claimant options, call the import RPC, and expose import progress state
+- [x] T012 [P] [US1] Implement `components/preferences/LegacyHistoryImportClaimantModal.tsx` for explicit claimant selection and ambiguous-name guardrails
+- [x] T013 [US1] Implement `components/preferences/LegacyHistoryImportSection.tsx` and wire it into `app/userPreferences.tsx` and `app/style/userPreferencesStyles.ts` so Settings shows the import entry point and current status
+
+**Checkpoint**: The first successful import flow is available in Settings and can be tested on its own.
+
+---
+
+## Phase 4: User Story 2 - Avoid Duplicate Imports (Priority: P1)
+
+**Goal**: Retrying the import is safe, and an already-completed account import does not create duplicate cloud sessions.
+
+**Independent Test**: Run the same import twice against the same local history and confirm the second run reports already-imported or skipped statuses without increasing cloud session counts.
+
+### Tests for User Story 2 (REQUIRED coverage) ⚠️
+
+- [x] T014 [P] [US2] Add pgTAP coverage in `supabase/tests/database/130_legacy_history_import_dedupe.test.sql` and `supabase/tests/database/150_legacy_history_import_retry.test.sql` for duplicate fingerprints, partial retries, and completed-account no-op behavior
+- [x] T015 [P] [US2] Extend `__tests__/components/preferences/LegacyHistoryImport.platform.test.tsx` with already-imported, retry, and failure-state regressions
+- [x] T016 [P] [US2] Extend `e2e/features/legacy-history-import.feature`, `e2e/steps/legacy-history-import.steps.ts`, and `e2e/steps/browser-flow.helpers.ts` with a repeated-run/no-op scenario
+
+### Implementation for User Story 2
+
+- [x] T017 [US2] Update `hooks/useLegacyHistoryImport.ts` to map RPC responses into imported, skipped, failed, and completed states and to block duplicate reruns after completion
+- [x] T018 [US2] Update `components/preferences/LegacyHistoryImportSection.tsx` to show progress, retry, and already-imported messaging from the hook state
+
+**Checkpoint**: The importer is idempotent and safe to retry without duplicating cloud sessions.
+
+---
+
+## Phase 5: User Story 3 - Preserve Legacy Guest Participants (Priority: P2)
+
+**Goal**: Imported sessions keep non-account players as session-scoped guest snapshots instead of promoting them into permanent identities.
+
+**Independent Test**: Import a mixed registered/guest legacy session and confirm the guest rows remain session-scoped in the cloud schema.
+
+### Tests for User Story 3 (REQUIRED coverage) ⚠️
+
+- [x] T019 [P] [US3] Add pgTAP coverage in `supabase/tests/database/140_legacy_history_import_claim.test.sql` for claimed-participant mapping, guest-scoped participants, and cross-account isolation
+- [x] T020 [P] [US3] Extend `__tests__/utils/legacyHistoryImport.test.ts` with mixed-player normalization and guest-preservation regressions
+- [x] T021 [P] [US3] Extend `e2e/features/legacy-history-import.feature`, `e2e/steps/legacy-history-import.steps.ts`, and `e2e/steps/browser-flow.helpers.ts` with a mixed registered/guest session scenario
+
+### Implementation for User Story 3
+
+- [x] T022 [US3] Update `utils/legacyHistoryImport.ts` to preserve guest participants as session-scoped snapshots when building the normalized payload
+- [x] T023 [US3] Update `hooks/useLegacyHistoryImport.ts` to carry guest-preservation metadata through the RPC request and surface validation or conflict errors clearly
+
+**Checkpoint**: The importer preserves guest identity boundaries while still linking the signed-in account to the chosen claimant.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation, documentation sync, and repo-level checks.
+
+- [x] T024 [P] Sync `specs/010-local-cloud-import/quickstart.md`, `specs/010-local-cloud-import/contracts/legacy-history-import-contract.md`, and `specs/010-local-cloud-import/data-model.md` with any implementation details that changed during coding
+- [x] T025 [P] Run `npm run db:reset`, `npm run db:test`, `npx jest --runInBand __tests__/app/userPreferences.platform.test.tsx __tests__/components/preferences/LegacyHistoryImport.platform.test.tsx`, `npm run test:e2e`, and `npm run lint` from `specs/010-local-cloud-import/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - blocks all story work
+- **User Stories (Phase 3+)**: Depend on the shared foundation; US1 is the MVP and should land first
+- **Polish (Final Phase)**: Depends on the desired user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: The first import flow, claimant picker, and shared hook are the base slice
+- **User Story 2 (P1)**: Reuses the shared import flow from US1 to add retry and no-op behavior
+- **User Story 3 (P2)**: Reuses the same normalization path to preserve guest-scoped participants
+
+### Within Each User Story
+
+- Required tests are written before the story is marked done
+- Shared helper utilities come before feature-specific UI wiring
+- Database contracts are implemented before client calls that depend on them
+- Story complete before moving to the next priority slice
+
+### Parallel Opportunities
+
+- Setup tasks T001 and T002 can run in parallel
+- Foundational tasks T004 and T005 can run in parallel after the schema migration is decided
+- User Story 1 test tasks T006 through T010 can be developed in parallel once the RPC contract is fixed
+- User Story 1 implementation tasks T011 and T012 can be built in parallel, then T013 can wire the completed pieces together
+- User Story 2 test tasks T014 through T016 can run in parallel
+- User Story 3 test tasks T019 through T021 can run in parallel
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch the Settings regression and importer unit coverage together:
+Task: "Add pgTAP schema coverage in supabase/tests/database/120_legacy_history_import_schema.test.sql"
+Task: "Add unit coverage in __tests__/utils/legacyHistoryImport.test.ts"
+Task: "Add component-level coverage in __tests__/components/preferences/LegacyHistoryImport.platform.test.tsx"
+Task: "Add screen-level regression coverage in __tests__/app/userPreferences.platform.test.tsx"
+
+# Build the import building blocks together once the contract is fixed:
+Task: "Implement hooks/useLegacyHistoryImport.ts"
+Task: "Implement components/preferences/LegacyHistoryImportClaimantModal.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Stop and validate the first import flow before adding retry or guest-preservation work
+
+### Incremental Delivery
+
+1. Foundation ready
+2. Add User Story 1 and confirm the first successful import
+3. Add User Story 2 and confirm duplicate runs no-op or retry safely
+4. Add User Story 3 and confirm guest participants stay session-scoped
+5. Finish with docs and repo-level validation
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. One developer can own the database migrations and pgTAP coverage
+2. One developer can own the Settings UI and claimant modal
+3. One developer can own the Playwright BDD flow and browser-flow helpers
+4. Story 2 and Story 3 can then split across retry/idempotency and guest-preservation work once the shared flow is in place

--- a/supabase/migrations/023_legacy_history_import_schema.sql
+++ b/supabase/migrations/023_legacy_history_import_schema.sql
@@ -1,0 +1,888 @@
+-- 023_legacy_history_import_schema.sql
+-- Private ledger, helper functions, and public RPC wrapper for one-time legacy history import.
+CREATE SCHEMA IF NOT EXISTS private;
+REVOKE ALL ON SCHEMA private
+FROM PUBLIC,
+    anon,
+    authenticated;
+GRANT USAGE ON SCHEMA private TO authenticated,
+    service_role;
+DO $$ BEGIN IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type
+    WHERE typname = 'legacy_history_import_state'
+) THEN CREATE TYPE legacy_history_import_state AS ENUM (
+    'in_progress',
+    'completed',
+    'failed'
+);
+END IF;
+IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type
+    WHERE typname = 'legacy_history_import_session_state'
+) THEN CREATE TYPE legacy_history_import_session_state AS ENUM (
+    'pending',
+    'imported',
+    'skipped',
+    'failed',
+    'conflict'
+);
+END IF;
+END;
+$$;
+CREATE TABLE IF NOT EXISTS private.legacy_history_import_state (
+    account_id uuid PRIMARY KEY REFERENCES public.accounts(id) ON DELETE CASCADE,
+    claimed_local_participant_id text NOT NULL,
+    claimed_local_participant_name text NOT NULL,
+    state legacy_history_import_state NOT NULL DEFAULT 'in_progress',
+    started_at timestamptz NOT NULL DEFAULT now(),
+    completed_at timestamptz,
+    failed_at timestamptz,
+    last_error text,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+DO $$ BEGIN IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'private.legacy_history_import_state'::regclass
+        AND conname = 'chk_legacy_history_import_state_completed_at'
+) THEN
+ALTER TABLE private.legacy_history_import_state
+ADD CONSTRAINT chk_legacy_history_import_state_completed_at CHECK (
+        (
+            state = 'completed'
+            AND completed_at IS NOT NULL
+        )
+        OR (state != 'completed')
+    );
+END IF;
+IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'private.legacy_history_import_state'::regclass
+        AND conname = 'chk_legacy_history_import_state_failed_at'
+) THEN
+ALTER TABLE private.legacy_history_import_state
+ADD CONSTRAINT chk_legacy_history_import_state_failed_at CHECK (
+        (
+            state = 'failed'
+            AND failed_at IS NOT NULL
+        )
+        OR (state != 'failed')
+    );
+END IF;
+END;
+$$;
+CREATE TABLE IF NOT EXISTS private.legacy_history_import_sessions (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id uuid NOT NULL REFERENCES public.accounts(id) ON DELETE CASCADE,
+    source_fingerprint text NOT NULL,
+    source_local_session_id text NOT NULL,
+    claimed_local_participant_id text NOT NULL,
+    cloud_session_id uuid REFERENCES public.game_sessions(id) ON DELETE
+    SET NULL,
+        state legacy_history_import_session_state NOT NULL DEFAULT 'pending',
+        error_message text,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now(),
+        UNIQUE (account_id, source_fingerprint)
+);
+DO $$ BEGIN IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'private.legacy_history_import_sessions'::regclass
+        AND conname = 'chk_legacy_history_import_sessions_imported_cloud_session'
+) THEN
+ALTER TABLE private.legacy_history_import_sessions
+ADD CONSTRAINT chk_legacy_history_import_sessions_imported_cloud_session CHECK (
+        (
+            state = 'imported'
+            AND cloud_session_id IS NOT NULL
+        )
+        OR (state != 'imported')
+    );
+END IF;
+IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'private.legacy_history_import_sessions'::regclass
+        AND conname = 'chk_legacy_history_import_sessions_failed_message'
+) THEN
+ALTER TABLE private.legacy_history_import_sessions
+ADD CONSTRAINT chk_legacy_history_import_sessions_failed_message CHECK (
+        (
+            state IN ('failed', 'conflict')
+            AND error_message IS NOT NULL
+        )
+        OR (state NOT IN ('failed', 'conflict'))
+    );
+END IF;
+END;
+$$;
+CREATE INDEX IF NOT EXISTS idx_legacy_history_import_sessions_account_id ON private.legacy_history_import_sessions (account_id);
+CREATE INDEX IF NOT EXISTS idx_legacy_history_import_sessions_cloud_session_id ON private.legacy_history_import_sessions (cloud_session_id)
+WHERE cloud_session_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_legacy_history_import_sessions_state ON private.legacy_history_import_sessions (state);
+CREATE OR REPLACE FUNCTION private.try_parse_timestamptz(p_value text) RETURNS timestamptz LANGUAGE plpgsql STABLE
+SET search_path = '' AS $$ BEGIN IF p_value IS NULL
+    OR btrim(p_value) = '' THEN RETURN NULL;
+END IF;
+RETURN p_value::timestamptz;
+EXCEPTION
+WHEN OTHERS THEN RETURN NULL;
+END;
+$$;
+CREATE OR REPLACE FUNCTION private.compute_legacy_history_fingerprint(p_session jsonb) RETURNS text LANGUAGE sql IMMUTABLE
+SET search_path = '' AS $$
+SELECT encode(
+        extensions.digest(
+            jsonb_build_object(
+                'sourceLocalSessionId',
+                p_session->>'sourceLocalSessionId',
+                'savedAt',
+                p_session->>'savedAt',
+                'commonMatchId',
+                p_session->>'commonMatchId',
+                'matchesPerPlayer',
+                COALESCE((p_session->>'matchesPerPlayer')::integer, 0),
+                'players',
+                COALESCE(
+                    (
+                        SELECT jsonb_agg(
+                                jsonb_build_object(
+                                    'id',
+                                    player_entry->>'id',
+                                    'name',
+                                    player_entry->>'name',
+                                    'drinksTaken',
+                                    CASE
+                                        WHEN player_entry ? 'drinksTaken' THEN to_jsonb((player_entry->>'drinksTaken')::numeric)
+                                        ELSE 'null'::jsonb
+                                    END
+                                )
+                                ORDER BY player_entry->>'id'
+                            )
+                        FROM jsonb_array_elements(COALESCE(p_session->'players', '[]'::jsonb)) AS player_entry
+                    ),
+                    '[]'::jsonb
+                ),
+                'matches',
+                COALESCE(
+                    (
+                        SELECT jsonb_agg(
+                                jsonb_build_object(
+                                    'id',
+                                    match_entry->>'id',
+                                    'homeTeam',
+                                    match_entry->>'homeTeam',
+                                    'awayTeam',
+                                    match_entry->>'awayTeam',
+                                    'homeGoals',
+                                    COALESCE((match_entry->>'homeGoals')::integer, 0),
+                                    'awayGoals',
+                                    COALESCE((match_entry->>'awayGoals')::integer, 0),
+                                    'startTime',
+                                    match_entry->>'startTime'
+                                )
+                                ORDER BY match_entry->>'id'
+                            )
+                        FROM jsonb_array_elements(COALESCE(p_session->'matches', '[]'::jsonb)) AS match_entry
+                    ),
+                    '[]'::jsonb
+                ),
+                'playerAssignments',
+                COALESCE(
+                    (
+                        SELECT jsonb_object_agg(
+                                assignment_entry.player_id,
+                                assignment_entry.match_ids
+                            )
+                        FROM (
+                                SELECT assignment.key AS player_id,
+                                    COALESCE(
+                                        (
+                                            SELECT jsonb_agg(
+                                                    match_id
+                                                    ORDER BY match_id
+                                                )
+                                            FROM jsonb_array_elements_text(assignment.value) AS match_id
+                                        ),
+                                        '[]'::jsonb
+                                    ) AS match_ids
+                                FROM jsonb_each(
+                                        COALESCE(p_session->'playerAssignments', '{}'::jsonb)
+                                    ) AS assignment
+                                ORDER BY assignment.key
+                            ) AS assignment_entry
+                    ),
+                    '{}'::jsonb
+                )
+            )::text,
+            'sha256'
+        ),
+        'hex'
+    );
+$$;
+CREATE OR REPLACE FUNCTION private.import_legacy_history(
+        p_claimed_local_participant_id text,
+        p_sessions jsonb
+    ) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = '' AS $$
+DECLARE v_account_id uuid := auth.uid();
+v_import_state private.legacy_history_import_state %ROWTYPE;
+v_existing_session private.legacy_history_import_sessions %ROWTYPE;
+v_session jsonb;
+v_player jsonb;
+v_match jsonb;
+v_claimed_name text;
+v_session_claimed_local_participant_id text;
+v_session_claimed_name text;
+v_session_local_id text;
+v_source_fingerprint text;
+v_session_saved_at timestamptz;
+v_cloud_session_id uuid;
+v_participant_id uuid;
+v_claimed_participant_id uuid;
+v_match_id uuid;
+v_common_match_id uuid;
+v_participant_map jsonb;
+v_match_map jsonb;
+v_assignment_key text;
+v_assignment_value jsonb;
+v_local_match_id text;
+v_results jsonb := '[]'::jsonb;
+v_imported_count integer := 0;
+v_skipped_count integer := 0;
+v_failed_count integer := 0;
+v_any_failure boolean := FALSE;
+v_last_error text;
+BEGIN IF v_account_id IS NULL THEN RAISE EXCEPTION 'authenticated account required';
+END IF;
+IF jsonb_typeof(COALESCE(p_sessions, '[]'::jsonb)) <> 'array' THEN RAISE EXCEPTION 'sessions payload must be a JSON array';
+END IF;
+PERFORM 1
+FROM public.accounts
+WHERE id = v_account_id;
+IF NOT FOUND THEN RAISE EXCEPTION 'account not found for authenticated user %',
+v_account_id;
+END IF;
+SELECT player_entry->>'name' INTO v_claimed_name
+FROM jsonb_array_elements(COALESCE(p_sessions, '[]'::jsonb)) AS session_entry,
+    LATERAL jsonb_array_elements(
+        COALESCE(session_entry->'players', '[]'::jsonb)
+    ) AS player_entry
+WHERE player_entry->>'id' = p_claimed_local_participant_id
+LIMIT 1;
+IF v_claimed_name IS NULL THEN RAISE EXCEPTION 'claimed local participant % not found in submitted sessions',
+p_claimed_local_participant_id;
+END IF;
+SELECT * INTO v_import_state
+FROM private.legacy_history_import_state
+WHERE account_id = v_account_id FOR
+UPDATE;
+IF FOUND THEN IF v_import_state.claimed_local_participant_name <> v_claimed_name THEN RETURN jsonb_build_object(
+    'accountId',
+    v_account_id::text,
+    'importState',
+    'failed',
+    'claimedLocalParticipantId',
+    v_import_state.claimed_local_participant_id,
+    'summary',
+    jsonb_build_object(
+        'importedCount',
+        0,
+        'skippedCount',
+        0,
+        'failedCount',
+        1
+    ),
+    'sessions',
+    jsonb_build_array(
+        jsonb_build_object(
+            'sourceLocalSessionId',
+            NULL,
+            'sourceFingerprint',
+            NULL,
+            'state',
+            'conflict',
+            'errorMessage',
+            'Claimed local participant name does not match the existing import state.'
+        )
+    )
+);
+END IF;
+IF v_import_state.state = 'completed' THEN RETURN jsonb_build_object(
+    'accountId',
+    v_account_id::text,
+    'importState',
+    'completed',
+    'claimedLocalParticipantId',
+    v_import_state.claimed_local_participant_id,
+    'summary',
+    jsonb_build_object(
+        'importedCount',
+        0,
+        'skippedCount',
+        0,
+        'failedCount',
+        0
+    ),
+    'sessions',
+    '[]'::jsonb
+);
+END IF;
+UPDATE private.legacy_history_import_state
+SET claimed_local_participant_name = v_claimed_name,
+    state = 'in_progress',
+    failed_at = NULL,
+    last_error = NULL,
+    updated_at = now()
+WHERE account_id = v_account_id;
+ELSE
+INSERT INTO private.legacy_history_import_state (
+        account_id,
+        claimed_local_participant_id,
+        claimed_local_participant_name,
+        state,
+        started_at,
+        created_at,
+        updated_at
+    )
+VALUES (
+        v_account_id,
+        p_claimed_local_participant_id,
+        v_claimed_name,
+        'in_progress',
+        now(),
+        now(),
+        now()
+    );
+END IF;
+FOR v_session IN
+SELECT value
+FROM jsonb_array_elements(COALESCE(p_sessions, '[]'::jsonb)) LOOP v_session_local_id := COALESCE(v_session->>'sourceLocalSessionId', '');
+v_session_claimed_local_participant_id := COALESCE(
+    NULLIF(v_session->>'claimedLocalParticipantId', ''),
+    p_claimed_local_participant_id
+);
+SELECT player_entry->>'name' INTO v_session_claimed_name
+FROM jsonb_array_elements(COALESCE(v_session->'players', '[]'::jsonb)) AS player_entry
+WHERE player_entry->>'id' = v_session_claimed_local_participant_id
+LIMIT 1;
+v_source_fingerprint := private.compute_legacy_history_fingerprint(v_session);
+SELECT * INTO v_existing_session
+FROM private.legacy_history_import_sessions
+WHERE account_id = v_account_id
+    AND source_fingerprint = v_source_fingerprint FOR
+UPDATE;
+IF FOUND
+AND v_existing_session.claimed_local_participant_id <> v_session_claimed_local_participant_id THEN
+UPDATE private.legacy_history_import_sessions
+SET state = 'conflict',
+    error_message = 'Claimed local participant does not match the existing imported fingerprint.',
+    updated_at = now()
+WHERE account_id = v_account_id
+    AND source_fingerprint = v_source_fingerprint;
+v_results := v_results || jsonb_build_array(
+    jsonb_build_object(
+        'sourceLocalSessionId',
+        v_session_local_id,
+        'sourceFingerprint',
+        v_source_fingerprint,
+        'state',
+        'conflict',
+        'errorMessage',
+        'Claimed local participant does not match the existing imported fingerprint.'
+    )
+);
+v_failed_count := v_failed_count + 1;
+v_any_failure := TRUE;
+CONTINUE;
+END IF;
+IF FOUND
+AND v_existing_session.state = 'imported'
+AND v_existing_session.cloud_session_id IS NOT NULL THEN v_results := v_results || jsonb_build_array(
+    jsonb_build_object(
+        'sourceLocalSessionId',
+        v_existing_session.source_local_session_id,
+        'sourceFingerprint',
+        v_source_fingerprint,
+        'state',
+        'skipped',
+        'cloudSessionId',
+        v_existing_session.cloud_session_id::text
+    )
+);
+v_skipped_count := v_skipped_count + 1;
+CONTINUE;
+END IF;
+INSERT INTO private.legacy_history_import_sessions (
+        account_id,
+        source_fingerprint,
+        source_local_session_id,
+        claimed_local_participant_id,
+        state,
+        error_message,
+        created_at,
+        updated_at
+    )
+VALUES (
+        v_account_id,
+        v_source_fingerprint,
+        v_session_local_id,
+        v_session_claimed_local_participant_id,
+        'pending',
+        NULL,
+        now(),
+        now()
+    ) ON CONFLICT (account_id, source_fingerprint) DO
+UPDATE
+SET source_local_session_id = EXCLUDED.source_local_session_id,
+    claimed_local_participant_id = EXCLUDED.claimed_local_participant_id,
+    state = 'pending',
+    error_message = NULL,
+    updated_at = now();
+BEGIN IF v_session_claimed_name IS NULL THEN RAISE EXCEPTION 'claimed participant % is missing from source session %',
+v_session_claimed_local_participant_id,
+v_session_local_id;
+END IF;
+IF v_session_claimed_name <> v_claimed_name THEN RAISE EXCEPTION 'claimed participant name % does not match selected claimant name % for source session %',
+v_session_claimed_name,
+v_claimed_name,
+v_session_local_id;
+END IF;
+v_session_saved_at := COALESCE(
+    private.try_parse_timestamptz(v_session->>'savedAt'),
+    now()
+);
+v_participant_map := '{}'::jsonb;
+v_match_map := '{}'::jsonb;
+v_claimed_participant_id := NULL;
+v_common_match_id := NULL;
+INSERT INTO public.game_sessions (
+        host_account_id,
+        join_code,
+        state,
+        created_at,
+        started_at,
+        completed_at
+    )
+VALUES (
+        v_account_id,
+        format(
+            'IMP-%s-%s',
+            left(v_source_fingerprint, 12),
+            replace(extensions.gen_random_uuid()::text, '-', '')
+        ),
+        'in_progress',
+        v_session_saved_at,
+        v_session_saved_at,
+        NULL
+    )
+RETURNING id INTO v_cloud_session_id;
+FOR v_player IN
+SELECT value
+FROM jsonb_array_elements(COALESCE(v_session->'players', '[]'::jsonb)) LOOP
+INSERT INTO public.participants (
+        session_id,
+        account_id,
+        display_name,
+        membership_type,
+        current_drink_total,
+        guest_rejoin_token_hash,
+        created_at
+    )
+VALUES (
+        v_cloud_session_id,
+        CASE
+            WHEN v_player->>'id' = v_session_claimed_local_participant_id THEN v_account_id
+            ELSE NULL
+        END,
+        COALESCE(v_player->>'name', 'Unknown Player'),
+        CASE
+            WHEN v_player->>'id' = v_session_claimed_local_participant_id THEN 'registered'::public.participant_membership_type
+            ELSE 'guest'::public.participant_membership_type
+        END,
+        COALESCE((v_player->>'drinksTaken')::numeric, 0),
+        CASE
+            WHEN v_player->>'id' = v_session_claimed_local_participant_id THEN NULL
+            ELSE encode(
+                extensions.digest(
+                    concat(
+                        v_session_local_id,
+                        ':',
+                        COALESCE(v_player->>'id', ''),
+                        ':guest'
+                    ),
+                    'sha256'
+                ),
+                'hex'
+            )
+        END,
+        v_session_saved_at
+    )
+RETURNING id INTO v_participant_id;
+v_participant_map := v_participant_map || jsonb_build_object(
+    v_player->>'id',
+    v_participant_id::text
+);
+IF v_player->>'id' = v_session_claimed_local_participant_id THEN v_claimed_participant_id := v_participant_id;
+END IF;
+END LOOP;
+IF v_claimed_participant_id IS NULL THEN RAISE EXCEPTION 'claimed participant % could not be created for source session %',
+v_session_claimed_local_participant_id,
+v_session_local_id;
+END IF;
+INSERT INTO public.gameplay_events (
+        session_id,
+        sequence_number,
+        actor_participant_id,
+        event_type,
+        idempotency_key,
+        payload,
+        created_at
+    )
+VALUES (
+        v_cloud_session_id,
+        public.allocate_event_sequence(v_cloud_session_id),
+        v_claimed_participant_id,
+        'session_created',
+        'legacy-import:session-created',
+        jsonb_build_object(
+            'sourceLocalSessionId',
+            v_session_local_id,
+            'sourceFingerprint',
+            v_source_fingerprint,
+            'imported',
+            TRUE
+        ),
+        v_session_saved_at
+    );
+FOR v_player IN
+SELECT value
+FROM jsonb_array_elements(COALESCE(v_session->'players', '[]'::jsonb)) LOOP
+INSERT INTO public.gameplay_events (
+        session_id,
+        sequence_number,
+        actor_participant_id,
+        event_type,
+        idempotency_key,
+        payload,
+        created_at
+    )
+VALUES (
+        v_cloud_session_id,
+        public.allocate_event_sequence(v_cloud_session_id),
+        COALESCE(
+            (v_participant_map->>(v_player->>'id'))::uuid,
+            v_claimed_participant_id
+        ),
+        'participant_joined',
+        concat('legacy-import:participant:', v_player->>'id'),
+        jsonb_build_object(
+            'localParticipantId',
+            v_player->>'id',
+            'displayName',
+            COALESCE(v_player->>'name', 'Unknown Player'),
+            'membershipType',
+            CASE
+                WHEN v_player->>'id' = v_session_claimed_local_participant_id THEN 'registered'
+                ELSE 'guest'
+            END,
+            'currentDrinkTotal',
+            COALESCE((v_player->>'drinksTaken')::numeric, 0)
+        ),
+        v_session_saved_at
+    );
+END LOOP;
+FOR v_match IN
+SELECT value
+FROM jsonb_array_elements(COALESCE(v_session->'matches', '[]'::jsonb)) LOOP
+INSERT INTO public.matches (
+        session_id,
+        source_provider,
+        source_match_id,
+        home_team_name,
+        away_team_name,
+        kickoff_at,
+        home_score,
+        away_score,
+        created_at
+    )
+VALUES (
+        v_cloud_session_id,
+        'legacy_import',
+        NULLIF(v_match->>'id', ''),
+        COALESCE(v_match->>'homeTeam', 'Unknown Home Team'),
+        COALESCE(v_match->>'awayTeam', 'Unknown Away Team'),
+        private.try_parse_timestamptz(v_match->>'startTime'),
+        COALESCE((v_match->>'homeGoals')::integer, 0),
+        COALESCE((v_match->>'awayGoals')::integer, 0),
+        v_session_saved_at
+    )
+RETURNING id INTO v_match_id;
+v_match_map := v_match_map || jsonb_build_object(
+    v_match->>'id',
+    v_match_id::text
+);
+INSERT INTO public.gameplay_events (
+        session_id,
+        sequence_number,
+        actor_participant_id,
+        event_type,
+        idempotency_key,
+        payload,
+        created_at
+    )
+VALUES (
+        v_cloud_session_id,
+        public.allocate_event_sequence(v_cloud_session_id),
+        v_claimed_participant_id,
+        'match_added',
+        concat('legacy-import:match:', v_match->>'id'),
+        jsonb_build_object(
+            'localMatchId',
+            v_match->>'id',
+            'homeTeam',
+            COALESCE(v_match->>'homeTeam', 'Unknown Home Team'),
+            'awayTeam',
+            COALESCE(v_match->>'awayTeam', 'Unknown Away Team'),
+            'homeGoals',
+            COALESCE((v_match->>'homeGoals')::integer, 0),
+            'awayGoals',
+            COALESCE((v_match->>'awayGoals')::integer, 0),
+            'startTime',
+            v_match->>'startTime'
+        ),
+        v_session_saved_at
+    );
+END LOOP;
+FOR v_assignment_key,
+v_assignment_value IN
+SELECT key,
+    value
+FROM jsonb_each(
+        COALESCE(v_session->'playerAssignments', '{}'::jsonb)
+    ) LOOP FOR v_local_match_id IN
+SELECT value
+FROM jsonb_array_elements_text(COALESCE(v_assignment_value, '[]'::jsonb)) LOOP IF (v_participant_map->>v_assignment_key) IS NOT NULL
+    AND (v_match_map->>v_local_match_id) IS NOT NULL THEN
+INSERT INTO public.assignments (
+        session_id,
+        participant_id,
+        match_id,
+        created_at
+    )
+VALUES (
+        v_cloud_session_id,
+        (v_participant_map->>v_assignment_key)::uuid,
+        (v_match_map->>v_local_match_id)::uuid,
+        v_session_saved_at
+    ) ON CONFLICT (session_id, participant_id, match_id) DO NOTHING;
+END IF;
+END LOOP;
+END LOOP;
+IF EXISTS (
+    SELECT 1
+    FROM jsonb_each(
+            COALESCE(v_session->'playerAssignments', '{}'::jsonb)
+        )
+) THEN
+INSERT INTO public.gameplay_events (
+        session_id,
+        sequence_number,
+        actor_participant_id,
+        event_type,
+        idempotency_key,
+        payload,
+        created_at
+    )
+VALUES (
+        v_cloud_session_id,
+        public.allocate_event_sequence(v_cloud_session_id),
+        v_claimed_participant_id,
+        'assignment_replaced',
+        'legacy-import:assignments',
+        jsonb_build_object(
+            'assignments',
+            COALESCE(v_session->'playerAssignments', '{}'::jsonb)
+        ),
+        v_session_saved_at
+    );
+END IF;
+IF NULLIF(v_session->>'commonMatchId', '') IS NOT NULL THEN v_common_match_id := (v_match_map->>(v_session->>'commonMatchId'))::uuid;
+IF v_common_match_id IS NOT NULL THEN
+UPDATE public.game_sessions
+SET common_match_id = v_common_match_id
+WHERE id = v_cloud_session_id;
+INSERT INTO public.gameplay_events (
+        session_id,
+        sequence_number,
+        actor_participant_id,
+        event_type,
+        idempotency_key,
+        payload,
+        created_at
+    )
+VALUES (
+        v_cloud_session_id,
+        public.allocate_event_sequence(v_cloud_session_id),
+        v_claimed_participant_id,
+        'common_match_selected',
+        'legacy-import:common-match',
+        jsonb_build_object(
+            'localMatchId',
+            v_session->>'commonMatchId',
+            'cloudMatchId',
+            v_common_match_id::text
+        ),
+        v_session_saved_at
+    );
+END IF;
+END IF;
+INSERT INTO public.gameplay_events (
+        session_id,
+        sequence_number,
+        actor_participant_id,
+        event_type,
+        idempotency_key,
+        payload,
+        created_at
+    )
+VALUES (
+        v_cloud_session_id,
+        public.allocate_event_sequence(v_cloud_session_id),
+        v_claimed_participant_id,
+        'session_completed',
+        'legacy-import:session-completed',
+        jsonb_build_object(
+            'sourceFingerprint',
+            v_source_fingerprint,
+            'imported',
+            TRUE
+        ),
+        v_session_saved_at
+    );
+UPDATE public.game_sessions
+SET state = 'completed',
+    started_at = v_session_saved_at,
+    completed_at = v_session_saved_at
+WHERE id = v_cloud_session_id;
+UPDATE private.legacy_history_import_sessions
+SET cloud_session_id = v_cloud_session_id,
+    state = 'imported',
+    error_message = NULL,
+    updated_at = now()
+WHERE account_id = v_account_id
+    AND source_fingerprint = v_source_fingerprint;
+v_results := v_results || jsonb_build_array(
+    jsonb_build_object(
+        'sourceLocalSessionId',
+        v_session_local_id,
+        'sourceFingerprint',
+        v_source_fingerprint,
+        'state',
+        'imported',
+        'cloudSessionId',
+        v_cloud_session_id::text
+    )
+);
+v_imported_count := v_imported_count + 1;
+EXCEPTION
+WHEN OTHERS THEN v_last_error := SQLERRM;
+UPDATE private.legacy_history_import_sessions
+SET cloud_session_id = NULL,
+    state = 'failed',
+    error_message = v_last_error,
+    updated_at = now()
+WHERE account_id = v_account_id
+    AND source_fingerprint = v_source_fingerprint;
+v_results := v_results || jsonb_build_array(
+    jsonb_build_object(
+        'sourceLocalSessionId',
+        v_session_local_id,
+        'sourceFingerprint',
+        v_source_fingerprint,
+        'state',
+        'failed',
+        'errorMessage',
+        v_last_error
+    )
+);
+v_failed_count := v_failed_count + 1;
+v_any_failure := TRUE;
+END;
+END LOOP;
+IF v_any_failure THEN
+UPDATE private.legacy_history_import_state
+SET state = 'failed',
+    failed_at = now(),
+    completed_at = NULL,
+    last_error = COALESCE(
+        v_last_error,
+        'One or more legacy sessions failed to import.'
+    ),
+    updated_at = now()
+WHERE account_id = v_account_id;
+ELSE
+UPDATE private.legacy_history_import_state
+SET state = 'completed',
+    completed_at = now(),
+    failed_at = NULL,
+    last_error = NULL,
+    updated_at = now()
+WHERE account_id = v_account_id;
+END IF;
+RETURN jsonb_build_object(
+    'accountId',
+    v_account_id::text,
+    'importState',
+    CASE
+        WHEN v_any_failure THEN 'failed'
+        ELSE 'completed'
+    END,
+    'claimedLocalParticipantId',
+    p_claimed_local_participant_id,
+    'summary',
+    jsonb_build_object(
+        'importedCount',
+        v_imported_count,
+        'skippedCount',
+        v_skipped_count,
+        'failedCount',
+        v_failed_count
+    ),
+    'sessions',
+    v_results
+);
+END;
+$$;
+REVOKE ALL ON FUNCTION private.try_parse_timestamptz(text)
+FROM PUBLIC,
+    anon;
+GRANT EXECUTE ON FUNCTION private.try_parse_timestamptz(text) TO authenticated,
+    service_role;
+REVOKE ALL ON FUNCTION private.compute_legacy_history_fingerprint(jsonb)
+FROM PUBLIC,
+    anon;
+GRANT EXECUTE ON FUNCTION private.compute_legacy_history_fingerprint(jsonb) TO authenticated,
+    service_role;
+REVOKE ALL ON FUNCTION private.import_legacy_history(text, jsonb)
+FROM PUBLIC,
+    anon;
+GRANT EXECUTE ON FUNCTION private.import_legacy_history(text, jsonb) TO authenticated,
+    service_role;
+CREATE OR REPLACE FUNCTION public.import_legacy_history(
+        claimed_local_participant_id text,
+        sessions jsonb
+    ) RETURNS jsonb LANGUAGE sql VOLATILE
+SET search_path = '' AS $$
+SELECT private.import_legacy_history(claimed_local_participant_id, sessions);
+$$;
+REVOKE ALL ON FUNCTION public.import_legacy_history(text, jsonb)
+FROM PUBLIC,
+    anon;
+GRANT EXECUTE ON FUNCTION public.import_legacy_history(text, jsonb) TO authenticated,
+    service_role;

--- a/supabase/tests/database/120_legacy_history_import_schema.test.sql
+++ b/supabase/tests/database/120_legacy_history_import_schema.test.sql
@@ -1,0 +1,197 @@
+-- 120_legacy_history_import_schema.test.sql
+BEGIN;
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+SELECT plan(20);
+SELECT ok(
+        to_regnamespace('private') IS NOT NULL,
+        'private schema exists'
+    );
+SELECT ok(
+        to_regclass('private.legacy_history_import_state') IS NOT NULL,
+        'legacy_history_import_state table exists'
+    );
+SELECT ok(
+        to_regclass('private.legacy_history_import_sessions') IS NOT NULL,
+        'legacy_history_import_sessions table exists'
+    );
+SELECT is(
+        (
+            SELECT string_agg(
+                    e.enumlabel,
+                    ','
+                    ORDER BY e.enumsortorder
+                )
+            FROM pg_enum e
+                JOIN pg_type t ON t.oid = e.enumtypid
+            WHERE t.typname = 'legacy_history_import_state'
+        ),
+        'in_progress,completed,failed',
+        'legacy_history_import_state enum contains expected values'
+    );
+SELECT is(
+        (
+            SELECT string_agg(
+                    e.enumlabel,
+                    ','
+                    ORDER BY e.enumsortorder
+                )
+            FROM pg_enum e
+                JOIN pg_type t ON t.oid = e.enumtypid
+            WHERE t.typname = 'legacy_history_import_session_state'
+        ),
+        'pending,imported,skipped,failed,conflict',
+        'legacy_history_import_session_state enum contains expected values'
+    );
+SELECT is(
+        (
+            SELECT string_agg(
+                    column_name || ':' || (
+                        CASE
+                            WHEN data_type = 'USER-DEFINED' THEN udt_name
+                            ELSE data_type
+                        END
+                    ) || ':' || is_nullable,
+                    ','
+                    ORDER BY ordinal_position
+                )
+            FROM information_schema.columns
+            WHERE table_schema = 'private'
+                AND table_name = 'legacy_history_import_state'
+        ),
+        'account_id:uuid:NO,claimed_local_participant_id:text:NO,claimed_local_participant_name:text:NO,state:legacy_history_import_state:NO,started_at:timestamp with time zone:NO,completed_at:timestamp with time zone:YES,failed_at:timestamp with time zone:YES,last_error:text:YES,created_at:timestamp with time zone:NO,updated_at:timestamp with time zone:NO',
+        'legacy_history_import_state columns, types, and nullability match expectations'
+    );
+SELECT is(
+        (
+            SELECT string_agg(
+                    column_name || ':' || (
+                        CASE
+                            WHEN data_type = 'USER-DEFINED' THEN udt_name
+                            ELSE data_type
+                        END
+                    ) || ':' || is_nullable,
+                    ','
+                    ORDER BY ordinal_position
+                )
+            FROM information_schema.columns
+            WHERE table_schema = 'private'
+                AND table_name = 'legacy_history_import_sessions'
+        ),
+        'id:uuid:NO,account_id:uuid:NO,source_fingerprint:text:NO,source_local_session_id:text:NO,claimed_local_participant_id:text:NO,cloud_session_id:uuid:YES,state:legacy_history_import_session_state:NO,error_message:text:YES,created_at:timestamp with time zone:NO,updated_at:timestamp with time zone:NO',
+        'legacy_history_import_sessions columns, types, and nullability match expectations'
+    );
+SELECT ok(
+        EXISTS (
+            SELECT 1
+            FROM pg_constraint
+            WHERE conrelid = 'private.legacy_history_import_state'::regclass
+                AND contype = 'f'
+                AND confrelid = 'public.accounts'::regclass
+        ),
+        'legacy_history_import_state.account_id references public.accounts(id)'
+    );
+SELECT ok(
+        EXISTS (
+            SELECT 1
+            FROM pg_constraint
+            WHERE conrelid = 'private.legacy_history_import_sessions'::regclass
+                AND contype = 'f'
+                AND confrelid = 'public.accounts'::regclass
+        ),
+        'legacy_history_import_sessions.account_id references public.accounts(id)'
+    );
+SELECT ok(
+        EXISTS (
+            SELECT 1
+            FROM pg_constraint
+            WHERE conrelid = 'private.legacy_history_import_sessions'::regclass
+                AND contype = 'f'
+                AND confrelid = 'public.game_sessions'::regclass
+        ),
+        'legacy_history_import_sessions.cloud_session_id references public.game_sessions(id)'
+    );
+SELECT ok(
+        EXISTS (
+            SELECT 1
+            FROM pg_indexes
+            WHERE schemaname = 'private'
+                AND tablename = 'legacy_history_import_sessions'
+                AND indexdef LIKE 'CREATE UNIQUE INDEX% (account_id, source_fingerprint)%'
+        ),
+        'legacy_history_import_sessions has a unique index on account_id and source_fingerprint'
+    );
+SELECT ok(
+        EXISTS (
+            SELECT 1
+            FROM pg_indexes
+            WHERE schemaname = 'private'
+                AND tablename = 'legacy_history_import_sessions'
+                AND indexname = 'idx_legacy_history_import_sessions_account_id'
+        ),
+        'legacy_history_import_sessions has an account_id index'
+    );
+SELECT ok(
+        EXISTS (
+            SELECT 1
+            FROM pg_indexes
+            WHERE schemaname = 'private'
+                AND tablename = 'legacy_history_import_sessions'
+                AND indexname = 'idx_legacy_history_import_sessions_cloud_session_id'
+                AND indexdef LIKE '%WHERE (cloud_session_id IS NOT NULL)%'
+        ),
+        'legacy_history_import_sessions has a partial cloud_session_id index'
+    );
+SELECT ok(
+        EXISTS (
+            SELECT 1
+            FROM pg_indexes
+            WHERE schemaname = 'private'
+                AND tablename = 'legacy_history_import_sessions'
+                AND indexname = 'idx_legacy_history_import_sessions_state'
+        ),
+        'legacy_history_import_sessions has a state index'
+    );
+SELECT ok(
+        EXISTS (
+            SELECT 1
+            FROM pg_constraint
+            WHERE conrelid = 'private.legacy_history_import_state'::regclass
+                AND conname = 'chk_legacy_history_import_state_completed_at'
+        ),
+        'legacy_history_import_state completed_at check constraint exists'
+    );
+SELECT ok(
+        EXISTS (
+            SELECT 1
+            FROM pg_constraint
+            WHERE conrelid = 'private.legacy_history_import_sessions'::regclass
+                AND conname = 'chk_legacy_history_import_sessions_failed_message'
+        ),
+        'legacy_history_import_sessions failed_message check constraint exists'
+    );
+SELECT ok(
+        to_regprocedure(
+            'private.compute_legacy_history_fingerprint(jsonb)'
+        ) IS NOT NULL,
+        'private.compute_legacy_history_fingerprint(jsonb) exists'
+    );
+SELECT ok(
+        to_regprocedure('private.import_legacy_history(text, jsonb)') IS NOT NULL,
+        'private.import_legacy_history(text, jsonb) exists'
+    );
+SELECT ok(
+        to_regprocedure('public.import_legacy_history(text, jsonb)') IS NOT NULL,
+        'public.import_legacy_history(text, jsonb) exists'
+    );
+SELECT ok(
+        has_function_privilege(
+            'authenticated',
+            'public.import_legacy_history(text, jsonb)',
+            'EXECUTE'
+        ),
+        'authenticated can execute public.import_legacy_history(text, jsonb)'
+    );
+SELECT *
+FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/130_legacy_history_import_dedupe.test.sql
+++ b/supabase/tests/database/130_legacy_history_import_dedupe.test.sql
@@ -1,0 +1,294 @@
+-- 130_legacy_history_import_dedupe.test.sql
+BEGIN;
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+SELECT plan(15);
+CREATE TEMP TABLE legacy_history_import_context AS WITH inserted_auth_user AS (
+    INSERT INTO auth.users (
+            id,
+            aud,
+            role,
+            email,
+            email_confirmed_at,
+            created_at,
+            updated_at,
+            raw_app_meta_data,
+            raw_user_meta_data,
+            is_sso_user,
+            is_anonymous
+        )
+    VALUES (
+            gen_random_uuid(),
+            'authenticated',
+            'authenticated',
+            'legacy-import-dedupe@test.local',
+            now(),
+            now(),
+            now(),
+            '{"provider":"email","providers":["email"]}'::jsonb,
+            '{}'::jsonb,
+            FALSE,
+            FALSE
+        )
+    RETURNING id
+),
+inserted_account AS (
+    INSERT INTO public.accounts (id, preferred_display_name)
+    SELECT id,
+        'Legacy Import Dedupe'
+    FROM inserted_auth_user
+    RETURNING id
+)
+SELECT id AS account_id
+FROM inserted_account;
+CREATE TEMP TABLE legacy_history_import_payloads AS
+SELECT jsonb_build_array(
+        jsonb_build_object(
+            'sourceLocalSessionId',
+            'legacy-session-a',
+            'savedAt',
+            '2026-05-01T19:00:00.000Z',
+            'players',
+            jsonb_build_array(
+                jsonb_build_object(
+                    'id',
+                    'alex-session-a',
+                    'name',
+                    'Alex Example',
+                    'drinksTaken',
+                    2
+                ),
+                jsonb_build_object(
+                    'id',
+                    'jordan-session-a',
+                    'name',
+                    'Jordan Guest',
+                    'drinksTaken',
+                    1
+                )
+            ),
+            'matches',
+            jsonb_build_array(
+                jsonb_build_object(
+                    'id',
+                    'legacy-match-a-1',
+                    'homeTeam',
+                    'Arsenal',
+                    'awayTeam',
+                    'Chelsea',
+                    'homeGoals',
+                    2,
+                    'awayGoals',
+                    1
+                )
+            ),
+            'commonMatchId',
+            'legacy-match-a-1',
+            'playerAssignments',
+            jsonb_build_object(
+                'alex-session-a',
+                jsonb_build_array('legacy-match-a-1'),
+                'jordan-session-a',
+                jsonb_build_array('legacy-match-a-1')
+            ),
+            'matchesPerPlayer',
+            1
+        )
+    ) AS single_session;
+CREATE TEMP TABLE legacy_history_import_runs (
+    run_name text PRIMARY KEY,
+    response jsonb NOT NULL
+);
+GRANT SELECT ON TABLE legacy_history_import_context TO authenticated;
+GRANT SELECT ON TABLE legacy_history_import_payloads TO authenticated;
+GRANT SELECT ON TABLE private.legacy_history_import_state TO authenticated;
+GRANT SELECT ON TABLE private.legacy_history_import_sessions TO authenticated;
+GRANT SELECT,
+    INSERT ON TABLE legacy_history_import_runs TO authenticated;
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.role', 'authenticated', true);
+SELECT set_config(
+        'request.jwt.claim.sub',
+        (
+            SELECT account_id::text
+            FROM legacy_history_import_context
+        ),
+        true
+    );
+INSERT INTO legacy_history_import_runs
+VALUES (
+        'first',
+        public.import_legacy_history(
+            'alex-session-a',
+            (
+                SELECT single_session
+                FROM legacy_history_import_payloads
+            )
+        )
+    );
+INSERT INTO legacy_history_import_runs
+VALUES (
+        'second',
+        public.import_legacy_history(
+            'alex-session-a',
+            (
+                SELECT single_session
+                FROM legacy_history_import_payloads
+            )
+        )
+    );
+SELECT is(
+        (
+            SELECT response->>'importState'
+            FROM legacy_history_import_runs
+            WHERE run_name = 'first'
+        ),
+        'completed',
+        'first import completes'
+    );
+SELECT is(
+        (
+            SELECT response->'summary'->>'importedCount'
+            FROM legacy_history_import_runs
+            WHERE run_name = 'first'
+        ),
+        '1',
+        'first import creates one session'
+    );
+SELECT is(
+        (
+            SELECT response->'summary'->>'skippedCount'
+            FROM legacy_history_import_runs
+            WHERE run_name = 'first'
+        ),
+        '0',
+        'first import skips nothing'
+    );
+SELECT is(
+        (
+            SELECT response->'summary'->>'failedCount'
+            FROM legacy_history_import_runs
+            WHERE run_name = 'first'
+        ),
+        '0',
+        'first import fails nothing'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.game_sessions
+            WHERE host_account_id = (
+                    SELECT account_id
+                    FROM legacy_history_import_context
+                )
+        ),
+        '1',
+        'first import creates one cloud session'
+    );
+SELECT is(
+        (
+            SELECT state::text
+            FROM private.legacy_history_import_state
+            WHERE account_id = (
+                    SELECT account_id
+                    FROM legacy_history_import_context
+                )
+        ),
+        'completed',
+        'import state is completed after the first run'
+    );
+SELECT ok(
+        (
+            SELECT completed_at IS NOT NULL
+            FROM private.legacy_history_import_state
+            WHERE account_id = (
+                    SELECT account_id
+                    FROM legacy_history_import_context
+                )
+        ),
+        'import completion timestamp is recorded'
+    );
+SELECT is(
+        (
+            SELECT response->>'importState'
+            FROM legacy_history_import_runs
+            WHERE run_name = 'second'
+        ),
+        'completed',
+        'second import stays completed'
+    );
+SELECT is(
+        (
+            SELECT response->'summary'->>'importedCount'
+            FROM legacy_history_import_runs
+            WHERE run_name = 'second'
+        ),
+        '0',
+        'second import is a no-op'
+    );
+SELECT is(
+        (
+            SELECT response->'summary'->>'skippedCount'
+            FROM legacy_history_import_runs
+            WHERE run_name = 'second'
+        ),
+        '0',
+        'second import skips nothing'
+    );
+SELECT is(
+        (
+            SELECT response->'summary'->>'failedCount'
+            FROM legacy_history_import_runs
+            WHERE run_name = 'second'
+        ),
+        '0',
+        'second import fails nothing'
+    );
+SELECT is(
+        (
+            SELECT jsonb_array_length(response->'sessions')::text
+            FROM legacy_history_import_runs
+            WHERE run_name = 'second'
+        ),
+        '0',
+        'second import returns no session results'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.game_sessions
+            WHERE host_account_id = (
+                    SELECT account_id
+                    FROM legacy_history_import_context
+                )
+        ),
+        '1',
+        'completed import does not create duplicate cloud sessions'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM private.legacy_history_import_sessions
+            WHERE account_id = (
+                    SELECT account_id
+                    FROM legacy_history_import_context
+                )
+        ),
+        '1',
+        'completed import does not create duplicate ledger rows'
+    );
+SELECT is(
+        (
+            SELECT state::text
+            FROM private.legacy_history_import_sessions
+            WHERE account_id = (
+                    SELECT account_id
+                    FROM legacy_history_import_context
+                )
+        ),
+        'imported',
+        'ledger row remains imported after the retry attempt'
+    );
+SELECT *
+FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/140_legacy_history_import_claim.test.sql
+++ b/supabase/tests/database/140_legacy_history_import_claim.test.sql
@@ -1,0 +1,408 @@
+-- 140_legacy_history_import_claim.test.sql
+BEGIN;
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+SELECT plan(16);
+CREATE TEMP TABLE legacy_history_import_accounts AS WITH first_auth AS (
+    INSERT INTO auth.users (
+            id,
+            aud,
+            role,
+            email,
+            email_confirmed_at,
+            created_at,
+            updated_at,
+            raw_app_meta_data,
+            raw_user_meta_data,
+            is_sso_user,
+            is_anonymous
+        )
+    VALUES (
+            gen_random_uuid(),
+            'authenticated',
+            'authenticated',
+            'legacy-import-claim-first@test.local',
+            now(),
+            now(),
+            now(),
+            '{"provider":"email","providers":["email"]}'::jsonb,
+            '{}'::jsonb,
+            FALSE,
+            FALSE
+        )
+    RETURNING id
+),
+first_account AS (
+    INSERT INTO public.accounts (id, preferred_display_name)
+    SELECT id,
+        'Legacy Import Claim First'
+    FROM first_auth
+    RETURNING id
+),
+second_auth AS (
+    INSERT INTO auth.users (
+            id,
+            aud,
+            role,
+            email,
+            email_confirmed_at,
+            created_at,
+            updated_at,
+            raw_app_meta_data,
+            raw_user_meta_data,
+            is_sso_user,
+            is_anonymous
+        )
+    VALUES (
+            gen_random_uuid(),
+            'authenticated',
+            'authenticated',
+            'legacy-import-claim-second@test.local',
+            now(),
+            now(),
+            now(),
+            '{"provider":"email","providers":["email"]}'::jsonb,
+            '{}'::jsonb,
+            FALSE,
+            FALSE
+        )
+    RETURNING id
+),
+second_account AS (
+    INSERT INTO public.accounts (id, preferred_display_name)
+    SELECT id,
+        'Legacy Import Claim Second'
+    FROM second_auth
+    RETURNING id
+)
+SELECT 'first'::text AS account_label,
+    id AS account_id
+FROM first_account
+UNION ALL
+SELECT 'second'::text AS account_label,
+    id AS account_id
+FROM second_account;
+CREATE TEMP TABLE legacy_history_import_payloads AS
+SELECT jsonb_build_array(
+        jsonb_build_object(
+            'sourceLocalSessionId',
+            'legacy-session-mixed',
+            'savedAt',
+            '2026-05-04T19:00:00.000Z',
+            'claimedLocalParticipantId',
+            'alex-session-a',
+            'players',
+            jsonb_build_array(
+                jsonb_build_object(
+                    'id',
+                    'alex-session-a',
+                    'name',
+                    'Alex Example',
+                    'drinksTaken',
+                    3
+                ),
+                jsonb_build_object(
+                    'id',
+                    'jordan-session-a',
+                    'name',
+                    'Jordan Guest',
+                    'drinksTaken',
+                    1
+                )
+            ),
+            'guestParticipants',
+            jsonb_build_array(
+                jsonb_build_object(
+                    'id',
+                    'jordan-session-a',
+                    'name',
+                    'Jordan Guest',
+                    'drinksTaken',
+                    1
+                )
+            ),
+            'matches',
+            jsonb_build_array(
+                jsonb_build_object(
+                    'id',
+                    'legacy-match-mixed-1',
+                    'homeTeam',
+                    'Arsenal',
+                    'awayTeam',
+                    'Chelsea',
+                    'homeGoals',
+                    3,
+                    'awayGoals',
+                    2
+                )
+            ),
+            'commonMatchId',
+            'legacy-match-mixed-1',
+            'playerAssignments',
+            jsonb_build_object(
+                'alex-session-a',
+                jsonb_build_array('legacy-match-mixed-1'),
+                'jordan-session-a',
+                jsonb_build_array('legacy-match-mixed-1')
+            ),
+            'matchesPerPlayer',
+            1
+        )
+    ) AS mixed_sessions;
+CREATE TEMP TABLE legacy_history_import_runs (
+    run_name text PRIMARY KEY,
+    response jsonb NOT NULL
+);
+GRANT SELECT ON TABLE legacy_history_import_accounts TO authenticated;
+GRANT SELECT ON TABLE legacy_history_import_payloads TO authenticated;
+GRANT SELECT ON TABLE private.legacy_history_import_state TO authenticated;
+GRANT SELECT ON TABLE private.legacy_history_import_sessions TO authenticated;
+GRANT SELECT,
+    INSERT ON TABLE legacy_history_import_runs TO authenticated;
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.role', 'authenticated', true);
+SELECT set_config(
+        'request.jwt.claim.sub',
+        (
+            SELECT account_id::text
+            FROM legacy_history_import_accounts
+            WHERE account_label = 'first'
+        ),
+        true
+    );
+INSERT INTO legacy_history_import_runs
+VALUES (
+        'first',
+        public.import_legacy_history(
+            'alex-session-a',
+            (
+                SELECT mixed_sessions
+                FROM legacy_history_import_payloads
+            )
+        )
+    );
+CREATE TEMP TABLE legacy_history_import_first_session AS
+SELECT id AS cloud_session_id
+FROM public.game_sessions
+WHERE host_account_id = (
+        SELECT account_id
+        FROM legacy_history_import_accounts
+        WHERE account_label = 'first'
+    )
+ORDER BY created_at DESC
+LIMIT 1;
+SELECT is(
+        (
+            SELECT response->>'importState'
+            FROM legacy_history_import_runs
+            WHERE run_name = 'first'
+        ),
+        'completed',
+        'first account import completes'
+    );
+SELECT is(
+        (
+            SELECT response->'summary'->>'importedCount'
+            FROM legacy_history_import_runs
+            WHERE run_name = 'first'
+        ),
+        '1',
+        'first account import writes one cloud session'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.game_sessions
+            WHERE host_account_id = (
+                    SELECT account_id
+                    FROM legacy_history_import_accounts
+                    WHERE account_label = 'first'
+                )
+        ),
+        '1',
+        'first account has one imported cloud session'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.participants
+            WHERE session_id = (
+                    SELECT cloud_session_id
+                    FROM legacy_history_import_first_session
+                )
+        ),
+        '2',
+        'first imported session keeps both participants'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.participants
+            WHERE session_id = (
+                    SELECT cloud_session_id
+                    FROM legacy_history_import_first_session
+                )
+                AND account_id = (
+                    SELECT account_id
+                    FROM legacy_history_import_accounts
+                    WHERE account_label = 'first'
+                )
+                AND membership_type = 'registered'
+        ),
+        '1',
+        'first imported session keeps the claimant registered'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.participants
+            WHERE session_id = (
+                    SELECT cloud_session_id
+                    FROM legacy_history_import_first_session
+                )
+                AND account_id IS NULL
+                AND membership_type = 'guest'
+        ),
+        '1',
+        'first imported session keeps the guest scoped to the session'
+    );
+SELECT set_config(
+        'request.jwt.claim.sub',
+        (
+            SELECT account_id::text
+            FROM legacy_history_import_accounts
+            WHERE account_label = 'second'
+        ),
+        true
+    );
+INSERT INTO legacy_history_import_runs
+VALUES (
+        'second',
+        public.import_legacy_history(
+            'alex-session-a',
+            (
+                SELECT mixed_sessions
+                FROM legacy_history_import_payloads
+            )
+        )
+    );
+CREATE TEMP TABLE legacy_history_import_second_session AS
+SELECT id AS cloud_session_id
+FROM public.game_sessions
+WHERE host_account_id = (
+        SELECT account_id
+        FROM legacy_history_import_accounts
+        WHERE account_label = 'second'
+    )
+ORDER BY created_at DESC
+LIMIT 1;
+SELECT is(
+        (
+            SELECT response->>'importState'
+            FROM legacy_history_import_runs
+            WHERE run_name = 'second'
+        ),
+        'completed',
+        'second account import completes'
+    );
+SELECT is(
+        (
+            SELECT response->'summary'->>'importedCount'
+            FROM legacy_history_import_runs
+            WHERE run_name = 'second'
+        ),
+        '1',
+        'second account import writes one cloud session'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.game_sessions
+            WHERE host_account_id = (
+                    SELECT account_id
+                    FROM legacy_history_import_accounts
+                    WHERE account_label = 'second'
+                )
+        ),
+        '1',
+        'second account has one imported cloud session'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.participants
+            WHERE session_id = (
+                    SELECT cloud_session_id
+                    FROM legacy_history_import_second_session
+                )
+        ),
+        '2',
+        'second imported session keeps both participants'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.participants
+            WHERE session_id = (
+                    SELECT cloud_session_id
+                    FROM legacy_history_import_second_session
+                )
+                AND account_id = (
+                    SELECT account_id
+                    FROM legacy_history_import_accounts
+                    WHERE account_label = 'second'
+                )
+                AND membership_type = 'registered'
+        ),
+        '1',
+        'second imported session keeps the claimant registered'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.participants
+            WHERE session_id = (
+                    SELECT cloud_session_id
+                    FROM legacy_history_import_second_session
+                )
+                AND account_id IS NULL
+                AND membership_type = 'guest'
+        ),
+        '1',
+        'second imported session keeps the guest scoped to the session'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM private.legacy_history_import_state
+        ),
+        '2',
+        'each account keeps its own import state row'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM private.legacy_history_import_sessions
+        ),
+        '2',
+        'each account keeps its own imported session ledger entry'
+    );
+SELECT is(
+        (
+            SELECT count(DISTINCT source_fingerprint)::text
+            FROM private.legacy_history_import_sessions
+        ),
+        '1',
+        'the same source fingerprint is reused across accounts without merging their ledgers'
+    );
+SELECT is(
+        (
+            SELECT count(DISTINCT account_id)::text
+            FROM private.legacy_history_import_sessions
+        ),
+        '2',
+        'the ledger isolates source rows per account'
+    );
+SELECT *
+FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/150_legacy_history_import_retry.test.sql
+++ b/supabase/tests/database/150_legacy_history_import_retry.test.sql
@@ -1,0 +1,407 @@
+-- 150_legacy_history_import_retry.test.sql
+BEGIN;
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+SELECT plan(10);
+CREATE TEMP TABLE legacy_history_import_context AS WITH inserted_auth_user AS (
+    INSERT INTO auth.users (
+            id,
+            aud,
+            role,
+            email,
+            email_confirmed_at,
+            created_at,
+            updated_at,
+            raw_app_meta_data,
+            raw_user_meta_data,
+            is_sso_user,
+            is_anonymous
+        )
+    VALUES (
+            gen_random_uuid(),
+            'authenticated',
+            'authenticated',
+            'legacy-import-retry@test.local',
+            now(),
+            now(),
+            now(),
+            '{"provider":"email","providers":["email"]}'::jsonb,
+            '{}'::jsonb,
+            FALSE,
+            FALSE
+        )
+    RETURNING id
+),
+inserted_account AS (
+    INSERT INTO public.accounts (id, preferred_display_name)
+    SELECT id,
+        'Legacy Import Retry'
+    FROM inserted_auth_user
+    RETURNING id
+)
+SELECT id AS account_id
+FROM inserted_account;
+CREATE TEMP TABLE legacy_history_import_payloads AS
+SELECT jsonb_build_object(
+        'sourceLocalSessionId',
+        'legacy-session-a',
+        'savedAt',
+        '2026-05-01T19:00:00.000Z',
+        'players',
+        jsonb_build_array(
+            jsonb_build_object(
+                'id',
+                'alex-session-a',
+                'name',
+                'Alex Example',
+                'drinksTaken',
+                2
+            ),
+            jsonb_build_object(
+                'id',
+                'jordan-session-a',
+                'name',
+                'Jordan Guest',
+                'drinksTaken',
+                1
+            )
+        ),
+        'matches',
+        jsonb_build_array(
+            jsonb_build_object(
+                'id',
+                'legacy-match-a-1',
+                'homeTeam',
+                'Arsenal',
+                'awayTeam',
+                'Chelsea',
+                'homeGoals',
+                2,
+                'awayGoals',
+                1
+            )
+        ),
+        'commonMatchId',
+        'legacy-match-a-1',
+        'playerAssignments',
+        jsonb_build_object(
+            'alex-session-a',
+            jsonb_build_array('legacy-match-a-1'),
+            'jordan-session-a',
+            jsonb_build_array('legacy-match-a-1')
+        ),
+        'matchesPerPlayer',
+        1
+    ) AS first_session,
+    jsonb_build_array(
+        jsonb_build_object(
+            'sourceLocalSessionId',
+            'legacy-session-a',
+            'savedAt',
+            '2026-05-01T19:00:00.000Z',
+            'players',
+            jsonb_build_array(
+                jsonb_build_object(
+                    'id',
+                    'alex-session-a',
+                    'name',
+                    'Alex Example',
+                    'drinksTaken',
+                    2
+                ),
+                jsonb_build_object(
+                    'id',
+                    'jordan-session-a',
+                    'name',
+                    'Jordan Guest',
+                    'drinksTaken',
+                    1
+                )
+            ),
+            'matches',
+            jsonb_build_array(
+                jsonb_build_object(
+                    'id',
+                    'legacy-match-a-1',
+                    'homeTeam',
+                    'Arsenal',
+                    'awayTeam',
+                    'Chelsea',
+                    'homeGoals',
+                    2,
+                    'awayGoals',
+                    1
+                )
+            ),
+            'commonMatchId',
+            'legacy-match-a-1',
+            'playerAssignments',
+            jsonb_build_object(
+                'alex-session-a',
+                jsonb_build_array('legacy-match-a-1'),
+                'jordan-session-a',
+                jsonb_build_array('legacy-match-a-1')
+            ),
+            'matchesPerPlayer',
+            1
+        ),
+        jsonb_build_object(
+            'sourceLocalSessionId',
+            'legacy-session-b',
+            'savedAt',
+            '2026-05-03T19:00:00.000Z',
+            'players',
+            jsonb_build_array(
+                jsonb_build_object(
+                    'id',
+                    'alex-session-a',
+                    'name',
+                    'Alex Example',
+                    'drinksTaken',
+                    4
+                ),
+                jsonb_build_object(
+                    'id',
+                    'jordan-session-b',
+                    'name',
+                    'Jordan Guest',
+                    'drinksTaken',
+                    3
+                )
+            ),
+            'matches',
+            jsonb_build_array(
+                jsonb_build_object(
+                    'id',
+                    'legacy-match-b-1',
+                    'homeTeam',
+                    'Liverpool',
+                    'awayTeam',
+                    'Everton',
+                    'homeGoals',
+                    3,
+                    'awayGoals',
+                    2
+                )
+            ),
+            'commonMatchId',
+            'legacy-match-b-1',
+            'playerAssignments',
+            jsonb_build_object(
+                'alex-session-a',
+                jsonb_build_array('legacy-match-b-1'),
+                'jordan-session-b',
+                jsonb_build_array('legacy-match-b-1')
+            ),
+            'matchesPerPlayer',
+            1
+        )
+    ) AS retry_sessions;
+CREATE TEMP TABLE legacy_history_import_seeded_sessions AS WITH seeded_game_session AS (
+    INSERT INTO public.game_sessions (host_account_id, join_code)
+    SELECT account_id,
+        'IMPRET1'
+    FROM legacy_history_import_context
+    RETURNING id,
+        host_account_id
+)
+SELECT *
+FROM seeded_game_session;
+INSERT INTO private.legacy_history_import_sessions (
+        account_id,
+        source_fingerprint,
+        source_local_session_id,
+        claimed_local_participant_id,
+        cloud_session_id,
+        state,
+        error_message,
+        created_at,
+        updated_at
+    )
+VALUES (
+        (
+            SELECT account_id
+            FROM legacy_history_import_context
+        ),
+        private.compute_legacy_history_fingerprint(
+            (
+                SELECT first_session
+                FROM legacy_history_import_payloads
+            )
+        ),
+        'legacy-session-a',
+        'alex-session-a',
+        (
+            SELECT id
+            FROM legacy_history_import_seeded_sessions
+        ),
+        'imported',
+        NULL,
+        now(),
+        now()
+    );
+INSERT INTO private.legacy_history_import_state (
+        account_id,
+        claimed_local_participant_id,
+        claimed_local_participant_name,
+        state,
+        started_at,
+        failed_at,
+        last_error,
+        created_at,
+        updated_at
+    )
+VALUES (
+        (
+            SELECT account_id
+            FROM legacy_history_import_context
+        ),
+        'alex-session-a',
+        'Alex Example',
+        'failed',
+        now(),
+        now(),
+        'Previous attempt failed.',
+        now(),
+        now()
+    );
+CREATE TEMP TABLE legacy_history_import_runs (
+    run_name text PRIMARY KEY,
+    response jsonb NOT NULL
+);
+GRANT SELECT ON TABLE legacy_history_import_context TO authenticated;
+GRANT SELECT ON TABLE legacy_history_import_payloads TO authenticated;
+GRANT SELECT ON TABLE legacy_history_import_seeded_sessions TO authenticated;
+GRANT SELECT ON TABLE private.legacy_history_import_state TO authenticated;
+GRANT SELECT ON TABLE private.legacy_history_import_sessions TO authenticated;
+GRANT SELECT,
+    INSERT ON TABLE legacy_history_import_runs TO authenticated;
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.role', 'authenticated', true);
+SELECT set_config(
+        'request.jwt.claim.sub',
+        (
+            SELECT account_id::text
+            FROM legacy_history_import_context
+        ),
+        true
+    );
+INSERT INTO legacy_history_import_runs
+VALUES (
+        'retry',
+        public.import_legacy_history(
+            'alex-session-a',
+            (
+                SELECT retry_sessions
+                FROM legacy_history_import_payloads
+            )
+        )
+    );
+SELECT is(
+        (
+            SELECT response->>'importState'
+            FROM legacy_history_import_runs
+            WHERE run_name = 'retry'
+        ),
+        'completed',
+        'retry import completes after the missing session is imported'
+    );
+SELECT is(
+        (
+            SELECT response->'summary'->>'importedCount'
+            FROM legacy_history_import_runs
+            WHERE run_name = 'retry'
+        ),
+        '1',
+        'retry import creates the remaining session'
+    );
+SELECT is(
+        (
+            SELECT response->'summary'->>'skippedCount'
+            FROM legacy_history_import_runs
+            WHERE run_name = 'retry'
+        ),
+        '1',
+        'retry import skips the already-imported session'
+    );
+SELECT is(
+        (
+            SELECT response->'summary'->>'failedCount'
+            FROM legacy_history_import_runs
+            WHERE run_name = 'retry'
+        ),
+        '0',
+        'retry import does not fail any sessions'
+    );
+SELECT is(
+        (
+            SELECT jsonb_array_length(response->'sessions')::text
+            FROM legacy_history_import_runs
+            WHERE run_name = 'retry'
+        ),
+        '2',
+        'retry import reports both session outcomes'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM public.game_sessions
+            WHERE host_account_id = (
+                    SELECT account_id
+                    FROM legacy_history_import_context
+                )
+        ),
+        '2',
+        'retry import creates only one additional cloud session'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM private.legacy_history_import_sessions
+            WHERE account_id = (
+                    SELECT account_id
+                    FROM legacy_history_import_context
+                )
+        ),
+        '2',
+        'retry import keeps a single ledger row per fingerprint'
+    );
+SELECT is(
+        (
+            SELECT count(*)::text
+            FROM private.legacy_history_import_sessions
+            WHERE account_id = (
+                    SELECT account_id
+                    FROM legacy_history_import_context
+                )
+                AND state = 'imported'
+        ),
+        '2',
+        'both ledger rows are imported after the retry'
+    );
+SELECT is(
+        (
+            SELECT state::text
+            FROM private.legacy_history_import_state
+            WHERE account_id = (
+                    SELECT account_id
+                    FROM legacy_history_import_context
+                )
+        ),
+        'completed',
+        'retry import clears the failed account state'
+    );
+SELECT ok(
+        (
+            SELECT completed_at IS NOT NULL
+            FROM private.legacy_history_import_state
+            WHERE account_id = (
+                    SELECT account_id
+                    FROM legacy_history_import_context
+                )
+        ),
+        'retry import records a completed timestamp'
+    );
+SELECT *
+FROM finish();
+ROLLBACK;

--- a/tamagui.config.ts
+++ b/tamagui.config.ts
@@ -1,6 +1,6 @@
 import { createTamagui } from "tamagui";
+import { darkTheme, lightTheme } from "./app/style/tamaguiThemes";
 import { tokens } from "./app/style/tamaguiTokens";
-import { lightTheme, darkTheme } from "./app/style/tamaguiThemes";
 
 const config = createTamagui({
   tokens,
@@ -14,7 +14,9 @@ const config = createTamagui({
 export type AppConfig = typeof config;
 
 declare module "tamagui" {
-  interface TamaguiCustomConfig extends AppConfig {}
+  interface TamaguiCustomConfig extends AppConfig {
+    readonly __configBrand?: never;
+  }
 }
 
 export default config;

--- a/types/legacyHistoryImport.ts
+++ b/types/legacyHistoryImport.ts
@@ -1,0 +1,145 @@
+import type { Match, Player } from "../store/store";
+
+/**
+ * Legacy import lifecycle for a signed-in account.
+ * @description Mirrors the account-level import-state enum stored in the private ledger.
+ */
+export type LegacyHistoryImportState = "in_progress" | "completed" | "failed";
+
+/**
+ * Per-session import lifecycle.
+ * @description Mirrors the per-session status stored in the private import ledger.
+ */
+export type LegacyHistoryImportSessionState =
+  | "pending"
+  | "imported"
+  | "skipped"
+  | "failed"
+  | "conflict";
+
+/**
+ * Mapping of local player identifiers to the local match identifiers they were assigned.
+ * @description Used by the importer to preserve the original assignment graph in the RPC payload.
+ */
+export type LegacyHistoryPlayerAssignments = Record<string, string[]>;
+
+/**
+ * Persisted local game session snapshot.
+ * @description Matches the AsyncStorage history shape written by the Zustand store.
+ */
+export interface LegacyLocalSessionSnapshot {
+  id: string;
+  date: string;
+  players: Player[];
+  matches: Match[];
+  commonMatchId: string | null;
+  playerAssignments: LegacyHistoryPlayerAssignments;
+  matchesPerPlayer: number;
+}
+
+/**
+ * Claimant option exposed in the Settings flow.
+ * @description Represents one local participant that the signed-in user can claim as their account.
+ */
+export interface LegacyHistoryClaimantOption {
+  id: string;
+  name: string;
+  sessionIds: string[];
+  sessionCount: number;
+}
+
+/**
+ * Player snapshot sent to the RPC.
+ * @description Preserves the original local participant identity and drink totals.
+ */
+export interface LegacyHistoryImportPlayerPayload {
+  id: string;
+  name: string;
+  drinksTaken?: number;
+}
+
+/**
+ * Guest participant snapshot sent alongside a session payload.
+ * @description Preserves session-scoped local players without promoting them into durable accounts.
+ */
+export type LegacyHistoryImportGuestParticipantPayload =
+  LegacyHistoryImportPlayerPayload;
+
+/**
+ * Match snapshot sent to the RPC.
+ * @description Preserves the original match identity, scoreline, and optional kickoff timestamp.
+ */
+export interface LegacyHistoryImportMatchPayload {
+  id: string;
+  homeTeam: string;
+  awayTeam: string;
+  homeGoals: number;
+  awayGoals: number;
+  startTime?: string;
+}
+
+/**
+ * Deterministic session fields used by the server-side source fingerprint.
+ * @description Excludes claimant identity so retries and wrong claimant choices do not change dedupe semantics.
+ */
+export interface LegacyHistorySourceFingerprintInput {
+  sourceLocalSessionId: string;
+  savedAt: string;
+  commonMatchId: string | null;
+  matchesPerPlayer: number;
+  players: LegacyHistoryImportPlayerPayload[];
+  matches: LegacyHistoryImportMatchPayload[];
+  playerAssignments: LegacyHistoryPlayerAssignments;
+}
+
+/**
+ * Normalized legacy session payload.
+ * @description The client sends this shape to the RPC instead of raw AsyncStorage internals.
+ */
+export interface LegacyHistoryImportSessionPayload extends LegacyHistorySourceFingerprintInput {
+  claimedLocalParticipantId: string;
+  guestParticipants: LegacyHistoryImportGuestParticipantPayload[];
+}
+
+/**
+ * RPC request body for the one-time importer.
+ * @description Sends one claimant choice plus the normalized local sessions eligible for import.
+ */
+export interface ImportLegacyHistoryRpcRequest {
+  claimedLocalParticipantId: string;
+  sessions: LegacyHistoryImportSessionPayload[];
+}
+
+/**
+ * Aggregate import counts returned by the RPC.
+ * @description Allows the client to render batch status without recomputing per-session results.
+ */
+export interface LegacyHistoryImportSummary {
+  importedCount: number;
+  skippedCount: number;
+  failedCount: number;
+}
+
+/**
+ * Per-session result returned by the RPC.
+ * @description Captures the server fingerprint, final status, and optional created cloud session id.
+ */
+export interface LegacyHistoryImportSessionResult {
+  sourceLocalSessionId: string;
+  sourceFingerprint: string;
+  state: LegacyHistoryImportSessionState;
+  cloudSessionId?: string;
+  errorMessage?: string;
+}
+
+/**
+ * RPC response for the one-time importer.
+ * @description Returns the account-level state plus the detailed per-session outcomes.
+ */
+export interface ImportLegacyHistoryRpcResponse {
+  accountId: string;
+  importState: LegacyHistoryImportState;
+  claimedLocalParticipantId: string;
+  summary: LegacyHistoryImportSummary;
+  sessions: LegacyHistoryImportSessionResult[];
+}

--- a/utils/legacyHistoryImport.ts
+++ b/utils/legacyHistoryImport.ts
@@ -1,0 +1,354 @@
+import type {
+  ImportLegacyHistoryRpcRequest,
+  LegacyHistoryClaimantOption,
+  LegacyHistoryImportGuestParticipantPayload,
+  LegacyHistoryImportMatchPayload,
+  LegacyHistoryImportPlayerPayload,
+  LegacyHistoryImportSessionPayload,
+  LegacyHistoryPlayerAssignments,
+  LegacyHistorySourceFingerprintInput,
+  LegacyLocalSessionSnapshot,
+} from "../types/legacyHistoryImport";
+
+export interface LegacyHistoryDerivedClaimantOption extends LegacyHistoryClaimantOption {
+  normalizedName: string;
+  sourceParticipantIds: string[];
+  sessionParticipantIds: Record<string, string[]>;
+  ambiguousSessionIds: string[];
+}
+
+const compareStrings = (left: string, right: string) =>
+  left.localeCompare(right);
+
+const compareSessions = (
+  left: LegacyLocalSessionSnapshot,
+  right: LegacyLocalSessionSnapshot,
+) => {
+  const bySavedAt = left.date.localeCompare(right.date);
+
+  if (bySavedAt !== 0) {
+    return bySavedAt;
+  }
+
+  return left.id.localeCompare(right.id);
+};
+
+const sortUniqueStrings = (values: string[]) => {
+  return [...new Set(values)].sort(compareStrings);
+};
+
+const pickRepresentativeParticipantId = (
+  sessionParticipantIds: Record<string, string[]>,
+  sessionIds: string[],
+) => {
+  const representativeSessionId =
+    sessionIds.find(
+      (sessionId) => sessionParticipantIds[sessionId].length === 1,
+    ) ?? sessionIds[0];
+
+  return representativeSessionId
+    ? sessionParticipantIds[representativeSessionId][0]
+    : "";
+};
+
+const pickDisplayName = (
+  displayNameCounts: Map<string, number>,
+  fallbackName: string,
+) => {
+  const countUppercaseCharacters = (value: string) => {
+    return (value.match(/[A-Z]/g) ?? []).length;
+  };
+
+  let selectedName = fallbackName;
+  let selectedCount = -1;
+
+  for (const [displayName, count] of displayNameCounts.entries()) {
+    const displayNameUppercaseCount = countUppercaseCharacters(displayName);
+    const selectedNameUppercaseCount = countUppercaseCharacters(selectedName);
+
+    if (
+      count > selectedCount ||
+      (count === selectedCount &&
+        displayNameUppercaseCount > selectedNameUppercaseCount) ||
+      (count === selectedCount &&
+        displayNameUppercaseCount === selectedNameUppercaseCount &&
+        displayName.length > selectedName.length) ||
+      (count === selectedCount && displayName.localeCompare(selectedName) < 0)
+    ) {
+      selectedName = displayName;
+      selectedCount = count;
+    }
+  }
+
+  return selectedName;
+};
+
+const formatLegacyHistoryParticipantName = (name: string) => {
+  return name.trim().replaceAll(/\s+/g, " ");
+};
+
+const buildStablePlayerAssignments = (
+  playerAssignments: LegacyHistoryPlayerAssignments,
+) => {
+  const stableAssignments: LegacyHistoryPlayerAssignments = {};
+
+  Object.keys(playerAssignments)
+    .sort(compareStrings)
+    .forEach((playerId) => {
+      stableAssignments[playerId] = sortUniqueStrings(
+        playerAssignments[playerId] ?? [],
+      );
+    });
+
+  return stableAssignments;
+};
+
+const buildPlayerPayloads = (
+  players: LegacyLocalSessionSnapshot["players"],
+): LegacyHistoryImportPlayerPayload[] => {
+  return [...players]
+    .map((player) => {
+      const payload: LegacyHistoryImportPlayerPayload = {
+        id: player.id,
+        name: player.name,
+      };
+
+      if (typeof player.drinksTaken === "number") {
+        payload.drinksTaken = player.drinksTaken;
+      }
+
+      return payload;
+    })
+    .sort((left, right) => left.id.localeCompare(right.id));
+};
+
+const buildMatchPayloads = (
+  matches: LegacyLocalSessionSnapshot["matches"],
+): LegacyHistoryImportMatchPayload[] => {
+  return [...matches]
+    .map((match) => {
+      const payload: LegacyHistoryImportMatchPayload = {
+        id: match.id,
+        homeTeam: match.homeTeam,
+        awayTeam: match.awayTeam,
+        homeGoals: match.homeGoals,
+        awayGoals: match.awayGoals,
+      };
+
+      if (match.startTime) {
+        payload.startTime = match.startTime;
+      }
+
+      return payload;
+    })
+    .sort((left, right) => left.id.localeCompare(right.id));
+};
+
+const buildGuestParticipantPayloads = (
+  players: LegacyLocalSessionSnapshot["players"],
+  claimedLocalParticipantId: string,
+): LegacyHistoryImportGuestParticipantPayload[] => {
+  return buildPlayerPayloads(players).filter(
+    (player) => player.id !== claimedLocalParticipantId,
+  );
+};
+
+const buildStableSessionParticipantIds = (
+  sessionParticipantIds: Record<string, string[]>,
+) => {
+  const stableParticipantIds: Record<string, string[]> = {};
+
+  Object.keys(sessionParticipantIds)
+    .sort(compareStrings)
+    .forEach((sessionId) => {
+      stableParticipantIds[sessionId] = sortUniqueStrings(
+        sessionParticipantIds[sessionId],
+      );
+    });
+
+  return stableParticipantIds;
+};
+
+export const normalizeLegacyHistoryParticipantName = (name: string) => {
+  return name.trim().replaceAll(/\s+/g, " ").toLocaleLowerCase();
+};
+
+export const buildLegacyHistoryClaimantOptions = (
+  sessions: LegacyLocalSessionSnapshot[],
+): LegacyHistoryDerivedClaimantOption[] => {
+  const claimantGroups = new Map<
+    string,
+    {
+      displayNameCounts: Map<string, number>;
+      sourceParticipantIds: Set<string>;
+      sessionParticipantIds: Record<string, string[]>;
+      fallbackName: string;
+    }
+  >();
+
+  [...sessions].sort(compareSessions).forEach((session) => {
+    [...session.players]
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .forEach((player) => {
+        const displayName = formatLegacyHistoryParticipantName(player.name);
+        const normalizedName = normalizeLegacyHistoryParticipantName(
+          player.name,
+        );
+
+        if (!normalizedName) {
+          return;
+        }
+
+        const existingGroup = claimantGroups.get(normalizedName);
+
+        if (existingGroup) {
+          existingGroup.displayNameCounts.set(
+            displayName,
+            (existingGroup.displayNameCounts.get(displayName) ?? 0) + 1,
+          );
+          existingGroup.sourceParticipantIds.add(player.id);
+          existingGroup.sessionParticipantIds[session.id] = [
+            ...(existingGroup.sessionParticipantIds[session.id] ?? []),
+            player.id,
+          ];
+          return;
+        }
+
+        claimantGroups.set(normalizedName, {
+          displayNameCounts: new Map([[displayName, 1]]),
+          sourceParticipantIds: new Set([player.id]),
+          sessionParticipantIds: { [session.id]: [player.id] },
+          fallbackName: displayName,
+        });
+      });
+  });
+
+  return [...claimantGroups.entries()]
+    .map(([normalizedName, claimantGroup]) => {
+      const sessionParticipantIds = buildStableSessionParticipantIds(
+        claimantGroup.sessionParticipantIds,
+      );
+      const sessionIds = Object.keys(sessionParticipantIds).sort(
+        compareStrings,
+      );
+      const ambiguousSessionIds = sessionIds.filter(
+        (sessionId) => sessionParticipantIds[sessionId].length > 1,
+      );
+      const sourceParticipantIds = sortUniqueStrings([
+        ...claimantGroup.sourceParticipantIds,
+      ]);
+
+      return {
+        id: pickRepresentativeParticipantId(sessionParticipantIds, sessionIds),
+        name: pickDisplayName(
+          claimantGroup.displayNameCounts,
+          claimantGroup.fallbackName,
+        ),
+        normalizedName,
+        sessionIds,
+        sessionCount: sessionIds.length,
+        sourceParticipantIds,
+        sessionParticipantIds,
+        ambiguousSessionIds,
+      };
+    })
+    .sort((left, right) => {
+      if (left.sessionCount !== right.sessionCount) {
+        return right.sessionCount - left.sessionCount;
+      }
+
+      const byName = left.name.localeCompare(right.name);
+
+      if (byName !== 0) {
+        return byName;
+      }
+
+      return left.id.localeCompare(right.id);
+    });
+};
+
+export const buildLegacyHistorySourceFingerprintInput = (
+  session: LegacyLocalSessionSnapshot,
+): LegacyHistorySourceFingerprintInput => {
+  return {
+    sourceLocalSessionId: session.id,
+    savedAt: session.date,
+    commonMatchId: session.commonMatchId,
+    matchesPerPlayer: session.matchesPerPlayer,
+    players: buildPlayerPayloads(session.players),
+    matches: buildMatchPayloads(session.matches),
+    playerAssignments: buildStablePlayerAssignments(session.playerAssignments),
+  };
+};
+
+export const buildLegacyHistoryImportSessionPayload = (
+  session: LegacyLocalSessionSnapshot,
+  claimedLocalParticipantId: string,
+): LegacyHistoryImportSessionPayload => {
+  if (
+    !session.players.some((player) => player.id === claimedLocalParticipantId)
+  ) {
+    throw new Error(
+      `Claimed participant ${claimedLocalParticipantId} is missing from source session ${session.id}.`,
+    );
+  }
+
+  return {
+    ...buildLegacyHistorySourceFingerprintInput(session),
+    claimedLocalParticipantId,
+    guestParticipants: buildGuestParticipantPayloads(
+      session.players,
+      claimedLocalParticipantId,
+    ),
+  };
+};
+
+export const buildLegacyHistoryImportSessions = ({
+  sessions,
+  claimant,
+}: {
+  sessions: LegacyLocalSessionSnapshot[];
+  claimant: LegacyHistoryDerivedClaimantOption;
+}) => {
+  if (claimant.ambiguousSessionIds.length > 0) {
+    throw new Error(
+      `Claimant ${claimant.name} is ambiguous in ${claimant.ambiguousSessionIds.length} legacy session(s).`,
+    );
+  }
+
+  const importSessions = [...sessions]
+    .sort(compareSessions)
+    .filter((session) => {
+      return (claimant.sessionParticipantIds[session.id] ?? []).length === 1;
+    })
+    .map((session) => {
+      const [claimedLocalParticipantId] =
+        claimant.sessionParticipantIds[session.id];
+
+      return buildLegacyHistoryImportSessionPayload(
+        session,
+        claimedLocalParticipantId,
+      );
+    });
+
+  if (importSessions.length === 0) {
+    throw new Error(
+      `Claimant ${claimant.name} was not found in any eligible legacy sessions.`,
+    );
+  }
+
+  return importSessions;
+};
+
+export const buildLegacyHistoryImportRequest = ({
+  sessions,
+  claimant,
+}: {
+  sessions: LegacyLocalSessionSnapshot[];
+  claimant: LegacyHistoryDerivedClaimantOption;
+}): ImportLegacyHistoryRpcRequest => {
+  return {
+    claimedLocalParticipantId: claimant.id,
+    sessions: buildLegacyHistoryImportSessions({ sessions, claimant }),
+  };
+};

--- a/utils/supabaseClient.ts
+++ b/utils/supabaseClient.ts
@@ -1,0 +1,117 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { Platform } from "react-native";
+
+import type {
+  ImportLegacyHistoryRpcRequest,
+  ImportLegacyHistoryRpcResponse,
+} from "../types/legacyHistoryImport";
+
+export interface SupabasePublicConfig {
+  url: string;
+  apiKey: string;
+}
+
+export interface LegacyHistoryImportRpcClient {
+  importLegacyHistory(
+    request: ImportLegacyHistoryRpcRequest,
+  ): Promise<ImportLegacyHistoryRpcResponse>;
+}
+
+let cachedSupabaseClient: SupabaseClient | null = null;
+let cachedLegacyHistoryImportRpcClient: LegacyHistoryImportRpcClient | null =
+  null;
+
+const readTrimmedEnvValue = (value: string | undefined) => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmedValue = value.trim();
+
+  return trimmedValue.length > 0 ? trimmedValue : null;
+};
+
+const readSupabaseUrl = () => {
+  return readTrimmedEnvValue(process.env.EXPO_PUBLIC_SUPABASE_URL);
+};
+
+const readSupabaseApiKey = () => {
+  return (
+    readTrimmedEnvValue(process.env.EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY) ??
+    readTrimmedEnvValue(process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY)
+  );
+};
+
+export const hasSupabasePublicConfig = () => {
+  return Boolean(readSupabaseUrl() && readSupabaseApiKey());
+};
+
+export const getSupabasePublicConfig = (): SupabasePublicConfig => {
+  const url = readSupabaseUrl();
+  const apiKey = readSupabaseApiKey();
+
+  if (!url || !apiKey) {
+    throw new Error(
+      "Missing Supabase public configuration. Set EXPO_PUBLIC_SUPABASE_URL and either EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY or EXPO_PUBLIC_SUPABASE_ANON_KEY.",
+    );
+  }
+
+  return { url, apiKey };
+};
+
+export const createSupabaseClient = (
+  config: SupabasePublicConfig = getSupabasePublicConfig(),
+) => {
+  return createClient(config.url, config.apiKey, {
+    auth: {
+      autoRefreshToken: true,
+      detectSessionInUrl: Platform.OS === "web",
+      persistSession: true,
+      storage: AsyncStorage,
+    },
+  });
+};
+
+export const getSupabaseClient = () => {
+  if (!cachedSupabaseClient) {
+    cachedSupabaseClient = createSupabaseClient();
+  }
+
+  return cachedSupabaseClient;
+};
+
+export const createLegacyHistoryImportRpcClient = (
+  client: SupabaseClient = getSupabaseClient(),
+): LegacyHistoryImportRpcClient => {
+  return {
+    async importLegacyHistory(request) {
+      const { data, error } = await client
+        .rpc("import_legacy_history", {
+          claimed_local_participant_id: request.claimedLocalParticipantId,
+          sessions: request.sessions,
+        })
+        .overrideTypes<ImportLegacyHistoryRpcResponse, { merge: false }>();
+
+      if (error) {
+        throw error;
+      }
+
+      if (!data) {
+        throw new Error(
+          "Supabase import_legacy_history returned no response payload.",
+        );
+      }
+
+      return data;
+    },
+  };
+};
+
+export const getLegacyHistoryImportRpcClient = () => {
+  if (!cachedLegacyHistoryImportRpcClient) {
+    cachedLegacyHistoryImportRpcClient = createLegacyHistoryImportRpcClient();
+  }
+
+  return cachedLegacyHistoryImportRpcClient;
+};


### PR DESCRIPTION
Implements the one-time local-to-cloud import flow for existing registered users.

Validation:
- npm run db:reset
- npm run db:test
- npm run test:e2e
- npm run lint

closes #127 