### PR TITLE
ci: add Playwright e2e CI job (Phase 2/12)

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -1,26 +1,58 @@
 name: e2e CI
 
+# Runs nightly (not per-PR) — the Playwright suite serializes to a single
+# worker in CI (see playwright.config.ts) to keep the shared dev-mode Expo
+# server alive, which makes a full run too slow to gate every PR. The
+# check-for-changes job skips the run entirely if nothing has landed on the
+# trunk branch since the last run, so an idle night costs nothing.
+#
+# NOTE: GitHub only fires `schedule` triggers for workflow files that exist
+# on the repository's configured default branch. This repo's default branch
+# is `master`, which currently lags the real trunk (`multiplayer`) — this
+# schedule will not actually fire until the workflow (and the code it tests)
+# reaches whichever branch is configured as default. workflow_dispatch works
+# immediately regardless, for manual runs in the meantime.
 on:
-  push:
-    paths-ignore:
-      - "command-api/**"
-      - "supabase/**"
-      - "specs/**"
-      - ".agents/**"
-      - "*.md"
-  pull_request:
-    paths-ignore:
-      - "command-api/**"
-      - "supabase/**"
-      - "specs/**"
-      - ".agents/**"
-      - "*.md"
+  schedule:
+    - cron: "0 3 * * *" # 03:00 UTC daily
+  workflow_dispatch: {}
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
+  check-for-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - name: Skip if nothing new landed since the last run
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Manual dispatch — running regardless of new commits."
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          last_sha=$(gh api "repos/${{ github.repository }}/actions/workflows/e2e-ci.yml/runs?status=completed&per_page=1" \
+            --jq '.workflow_runs[0].head_sha // empty')
+          current_sha="${{ github.sha }}"
+
+          if [ -z "$last_sha" ] || [ "$last_sha" != "$current_sha" ]; then
+            echo "New commits since last run ($last_sha -> $current_sha) — running."
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No new commits since last run ($current_sha) — skipping."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   playwright:
+    needs: check-for-changes
+    if: needs.check-for-changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.7
@@ -38,11 +70,6 @@ jobs:
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
-
-      - name: Debug runner resources (temporary, for investigating server crash)
-        run: |
-          echo "CPUs: $(nproc)"
-          free -h
 
       - name: Run e2e suite
         run: npm run test:e2e

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -1,0 +1,51 @@
+name: e2e CI
+
+on:
+  push:
+    paths-ignore:
+      - "command-api/**"
+      - "supabase/**"
+      - "specs/**"
+      - ".agents/**"
+      - "*.md"
+  pull_request:
+    paths-ignore:
+      - "command-api/**"
+      - "supabase/**"
+      - "specs/**"
+      - ".agents/**"
+      - "*.md"
+
+permissions:
+  contents: read
+
+jobs:
+  playwright:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.7
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v4.0.4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run e2e suite
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4.4.3
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -39,6 +39,11 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
+      - name: Debug runner resources (temporary, for investigating server crash)
+        run: |
+          echo "CPUs: $(nproc)"
+          free -h
+
       - name: Run e2e suite
         run: npm run test:e2e
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,6 +24,12 @@ export default defineConfig({
   testDir,
   timeout: 30_000,
   retries: 0,
+  // The webServer below is a single dev-mode (SSR-per-request) Expo/Metro
+  // instance shared by every worker and both projects. Under CI's default
+  // worker concurrency it was observed to crash mid-run (ERR_CONNECTION_REFUSED
+  // partway through; see specs/019-harden-codebase-foundations/tasks.md T008) —
+  // capping to 1 worker in CI serializes all requests to keep it alive.
+  workers: process.env.CI ? 1 : undefined,
   use: {
     baseURL,
     headless: true,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,12 +24,6 @@ export default defineConfig({
   testDir,
   timeout: 30_000,
   retries: 0,
-  // The webServer below is a single dev-mode (SSR-per-request) Expo/Metro
-  // instance shared by every worker and both projects. Under CI's default
-  // worker concurrency it was observed to crash mid-run (ERR_CONNECTION_REFUSED
-  // partway through; see specs/019-harden-codebase-foundations/tasks.md T008) —
-  // capping to 1 worker in CI serializes all requests to keep it alive.
-  workers: process.env.CI ? 1 : undefined,
   use: {
     baseURL,
     headless: true,
@@ -56,6 +50,16 @@ export default defineConfig({
     port: webPort,
     reuseExistingServer: true,
     env: {
+      // The dev-mode Expo/Metro server does SSR-per-request with no
+      // production build, and its heap grows over the course of a long
+      // e2e run until it hits Node's default old-space limit and crashes
+      // with "FATAL ERROR: Reached heap limit ... JavaScript heap out of
+      // memory" (surfaced ERR_CONNECTION_REFUSED downstream once the
+      // process died — see specs/019-harden-codebase-foundations/tasks.md
+      // T008/T008b). Raising the heap ceiling gives it enough room to
+      // finish the suite; GitHub-hosted ubuntu-latest runners have ample
+      // RAM to spare for this.
+      NODE_OPTIONS: process.env.NODE_OPTIONS ?? "--max-old-space-size=6144",
       EXPO_PUBLIC_SUPABASE_URL:
         process.env.EXPO_PUBLIC_SUPABASE_URL ??
         LEGACY_HISTORY_IMPORT_SUPABASE_URL,


### PR DESCRIPTION
## Summary
- Stacked on top of #169 (Phase 1: client-ci/db-ci) — Phase 2 of the 12-phase tech-debt remediation plan.
- Adds `.github/workflows/e2e-ci.yml` running the Playwright BDD suite nightly (schedule + workflow_dispatch, not per-PR — see below for why) against a self-booted Expo web server; backends mocked via `page.route()` in `e2e/steps/browser-flow.helpers.ts`.

## Investigation summary: 3 fix attempts, no working fix yet

**Root problem**: the self-booted dev-mode Expo/Metro server crashes on GitHub Actions with `net::ERR_CONNECTION_REFUSED` partway through a full run (originally 59/96 tests failed).

1. **`workers: 1`** (hypothesis: concurrent load kills the server) — **made it worse**: 71/96 failed. Serializing didn't help because concurrency was never the cause.
2. **Raised the dev server's heap ceiling** (`NODE_OPTIONS=--max-old-space-size=6144`) after finding the real crash in the logs: `FATAL ERROR: Reached heap limit ... JavaScript heap out of memory`. Confirmed the setting worked (GC log shows heap correctly reaching ~6.1–6.2GB) but it only delayed the crash. The leak is ~17MB/sec sustained — surviving a full run would need ~17GB, more than a GitHub-hosted runner has in total. **Not fixable by raising the limit further.**
3. **Switched to a static export** (`expo export -p web` + `serve -s dist`, no dev-mode SSR, nothing to leak) — eliminates the leak mechanism, but surfaces a *different* regression: 42/96 failed locally (vs. 14/96 on the original dev server), with real functional symptoms (a button stuck `aria-disabled="true"` indefinitely, another element never becoming visible within 90s) pointing at dev-vs-production behavioral/timing differences in app readiness that the e2e test-seeding depends on. This wasn't root-caused further and was **reverted** (never committed) rather than pushing a new failure mode.

Current state on this branch: heap-limit fix from attempt 2 is committed (real, if incomplete, improvement); attempts 1 and 3 were tried and abandoned. `e2e-ci` remains red/unreliable on GitHub Actions.

## Why this doesn't block anything

Per the nightly-cadence redesign (this PR): `e2e-ci` triggers on `schedule` (03:00 UTC) + `workflow_dispatch`, never on push/pull_request, and is **not** a required status check. A fully serialized run is 30-40+ min regardless of whether it passes — too slow to gate PRs either way. So this instability is an open investigation, not something in the way of merging client-ci/db-ci (#169) or anything else.

## ⚠️ Also unresolved: the schedule trigger itself won't fire yet

GitHub only runs `schedule`-triggered workflows from files that exist on the repo's **configured default branch**, which is `master` — 19 commits behind the actual trunk `multiplayer` and missing `supabase/`/`command-api/` entirely (see spec's research.md D10). Until this workflow reaches whichever branch is default, the nightly cron is inert; `workflow_dispatch` works now as a manual stopgap.

## Recommendation for whoever picks this up next
See `specs/019-harden-codebase-foundations/research.md` D11 for full detail. Options: (a) properly root-cause the dev-server memory leak, (b) properly root-cause the dev-vs-production readiness gap and make the static-export path work, or (c) run a smaller/shorter nightly e2e subset instead of the full 96 tests, sidestepping the long-run memory growth entirely.

## Test plan
- [x] Local run (dev server): 82 passed / 14 failed
- [x] GitHub Actions (dev server, default concurrency): 37 passed / 59 failed — `ERR_CONNECTION_REFUSED`
- [x] GitHub Actions (dev server, workers:1): 25 passed / 71 failed — worse
- [x] GitHub Actions (dev server, heap raised to 6144MB): still fails, confirmed via GC logs that the setting took effect but wasn't enough
- [x] Local run (static export): 54 passed / 42 failed — different regression, reverted
- [ ] A working fix — not yet found

🤖 Generated with [Claude Code](https://claude.com/claude-code)