### PR TITLE
build: upgrade command-api to Spring Boot 3.5.3 (Phase 5/12)

### DIFF
--- a/command-api/pom.xml
+++ b/command-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.5</version>
+        <version>3.5.3</version>
         <relativePath/>
     </parent>
 
@@ -18,9 +18,9 @@
 
     <properties>
         <java.version>17</java.version>
-        <springdoc.version>2.6.0</springdoc.version>
+        <springdoc.version>2.8.6</springdoc.version>
         <jjwt.version>0.12.6</jjwt.version>
-        <logstash.version>7.4</logstash.version>
+        <logstash.version>8.1</logstash.version>
         <caffeine.version>3.1.8</caffeine.version>
         <jacoco.version>0.8.12</jacoco.version>
         <dependency-check.version>10.0.4</dependency-check.version>
@@ -96,17 +96,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
-                <configuration>
-                    <source>17</source>
-                    <target>17</target>
-                    <fork>true</fork>
-                    <executable>javac</executable>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>


### PR DESCRIPTION
## Summary
- Stacked on top of #169 (Phase 1: client-ci/db-ci) — Phase 5 of the 12-phase tech-debt remediation plan. Independent of Phases 2/3/4.
- Boot 3.3.5 was past OSS support (ended mid-2025) — the JWT-validating command-api is exactly the component that needs to stay patchable.
- `spring-boot-starter-parent` 3.3.5 → **3.5.3** (latest stable 3.5.x, verified against Maven Central rather than assumed).
- `springdoc-openapi` 2.6.0 → **2.8.6** (2.6.0 targeted Framework 6.1/Boot 3.3 and was the highest-risk pin).
- `logstash-logback-encoder` 7.4 → **8.1** (Boot 3.5 ships Logback 1.5, which 7.4 predates).
- Removed the explicit `maven-compiler-plugin` 3.10.1 pin (incl. the `fork`/`executable=javac` override) — the existing `<java.version>17</java.version>` property already lets the Boot parent manage the compiler plugin version and release target; the extra block was redundant.
- `jjwt`, `caffeine`, `jacoco`, `dependency-check` left unchanged (already current / out of scope for this phase).

## Test plan
- [x] `mvnw clean verify` — **BUILD SUCCESS**, 75/75 tests passing
- [x] jacoco: "All coverage checks have been met" (0.60 line-coverage floor holds)
- [x] Manually started the service (`mvnw spring-boot:run`) and confirmed `/swagger-ui/index.html` and `/v3/api-docs` both return `200`
- [x] `/v3/api-docs` serves a valid OpenAPI 3.1.0 document listing the real endpoints (`/v1/rooms/{roomId}/commands/{commandType}`, `/v1/matches`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)