### PR TITLE
test: add hook tests, trivial/medium tier (Phase 9)

### DIFF
--- a/__tests__/hooks/useLeagueLogo.test.ts
+++ b/__tests__/hooks/useLeagueLogo.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import React from "react";
+import TestRenderer from "react-test-renderer";
+
+import { useLeagueLogo } from "../../hooks/useLeagueLogo";
+import { cacheLeagueLogo } from "../../utils/teamLogos";
+
+jest.mock("../../utils/teamLogos", () => ({
+  cacheLeagueLogo: jest.fn(),
+}));
+
+const mockCacheLeagueLogo = jest.mocked(cacheLeagueLogo);
+
+const renderHookProbe = (leagueName: string, leagueCode?: string) => {
+  let latest:
+    | { logoSource: unknown; isLoading: boolean }
+    | undefined;
+
+  const Probe = () => {
+    latest = useLeagueLogo(leagueName, leagueCode);
+    return null;
+  };
+
+  const renderer = TestRenderer.create(React.createElement(Probe));
+
+  return { renderer, getLatest: () => latest };
+};
+
+describe("useLeagueLogo", () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await AsyncStorage.clear();
+    (globalThis as { fetch?: unknown }).fetch = undefined;
+  });
+
+  it("resolves a bundled local asset synchronously without hitting storage or the network", async () => {
+    const { renderer, getLatest } = renderHookProbe("Premier League");
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getLatest()?.isLoading).toBe(false);
+    expect(getLatest()?.logoSource).toBeDefined();
+
+    renderer.unmount();
+  });
+
+  it("falls back to a cached AsyncStorage entry when no local asset matches", async () => {
+    await AsyncStorage.setItem(
+      "league_logo_Eredivisie",
+      "https://example.com/eredivisie.png",
+    );
+
+    const { renderer, getLatest } = renderHookProbe("Eredivisie");
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getLatest()?.logoSource).toEqual({
+      uri: "https://example.com/eredivisie.png",
+    });
+    expect(getLatest()?.isLoading).toBe(false);
+
+    renderer.unmount();
+  });
+
+  it("fetches from the ESPN API and caches the result when nothing is local or cached", async () => {
+    const fetchMock = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        leagues: [
+          {
+            logos: [
+              { rel: ["default", "full"], href: "https://espn.example/logo.png" },
+            ],
+          },
+        ],
+      }),
+    }));
+    (globalThis as { fetch: unknown }).fetch = fetchMock;
+
+    const { renderer, getLatest } = renderHookProbe("Eredivisie", "ned.1");
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://site.api.espn.com/apis/site/v2/sports/soccer/ned.1/scoreboard",
+    );
+    expect(mockCacheLeagueLogo).toHaveBeenCalledWith(
+      "Eredivisie",
+      "https://espn.example/logo.png",
+    );
+    expect(getLatest()?.logoSource).toEqual({
+      uri: "https://espn.example/logo.png",
+    });
+    expect(getLatest()?.isLoading).toBe(false);
+
+    renderer.unmount();
+  });
+
+  it("does not call the API when no leagueCode is provided, and leaves isLoading true (no completion path)", async () => {
+    const fetchMock = jest.fn();
+    (globalThis as { fetch: unknown }).fetch = fetchMock;
+
+    const { renderer, getLatest } = renderHookProbe("Eredivisie");
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(getLatest()?.logoSource).toBeUndefined();
+    expect(getLatest()?.isLoading).toBe(true);
+
+    renderer.unmount();
+  });
+
+  it("stops loading and logs when the API response is not ok", async () => {
+    const consoleWarnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const fetchMock = jest.fn(async () => ({ ok: false, status: 500 }));
+    (globalThis as { fetch: unknown }).fetch = fetchMock;
+
+    const { renderer, getLatest } = renderHookProbe("Eredivisie", "ned.1");
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(consoleWarnSpy).toHaveBeenCalled();
+    expect(getLatest()?.logoSource).toBeUndefined();
+
+    consoleWarnSpy.mockRestore();
+    renderer.unmount();
+  });
+
+  it("does not update state after unmount (unmount guard)", async () => {
+    let resolveFetch: (value: {
+      ok: boolean;
+      json: () => Promise<unknown>;
+    }) => void = () => undefined;
+    const fetchMock = jest.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve as typeof resolveFetch;
+        }),
+    );
+    (globalThis as { fetch: unknown }).fetch = fetchMock;
+
+    const { renderer, getLatest } = renderHookProbe("Eredivisie", "ned.1");
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    renderer.unmount();
+
+    await TestRenderer.act(async () => {
+      resolveFetch({
+        ok: true,
+        json: async () => ({
+          leagues: [
+            {
+              logos: [
+                {
+                  rel: ["default"],
+                  href: "https://espn.example/late.png",
+                },
+              ],
+            },
+          ],
+        }),
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getLatest()?.logoSource).toBeUndefined();
+  });
+});

--- a/__tests__/hooks/useMatchListFilters.test.ts
+++ b/__tests__/hooks/useMatchListFilters.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "@jest/globals";
+import React from "react";
+import TestRenderer from "react-test-renderer";
+
+import { LeagueEndpoint } from "../../constants/leagues";
+import { useMatchListFilters } from "../../hooks/useMatchListFilters";
+import { TeamWithLeague } from "../../utils/matchUtils";
+
+type HookResult = ReturnType<typeof useMatchListFilters>;
+
+const PREMIER_LEAGUE: LeagueEndpoint = { name: "Premier League", code: "eng.1" };
+const CHAMPIONSHIP: LeagueEndpoint = { name: "Championship", code: "eng.2" };
+const BUNDESLIGA: LeagueEndpoint = { name: "Bundesliga", code: "ger.1" };
+
+const ALL_TEAMS: TeamWithLeague[] = [
+  { key: "arsenal", value: "Arsenal FC", league: "Premier League" },
+  { key: "dortmund", value: "Borussia Dortmund", league: "Bundesliga" },
+];
+
+const renderHookProbe = (
+  storedDefaultLeagues: LeagueEndpoint[] = [],
+  allTeamsData: TeamWithLeague[] = ALL_TEAMS,
+) => {
+  let latest: HookResult | undefined;
+
+  const Probe = () => {
+    latest = useMatchListFilters({ storedDefaultLeagues, allTeamsData });
+    return null;
+  };
+
+  const renderer = TestRenderer.create(React.createElement(Probe));
+
+  return { renderer, getLatest: () => latest as HookResult };
+};
+
+describe("useMatchListFilters", () => {
+  it("falls back to the built-in default leagues when none are stored", () => {
+    const { renderer, getLatest } = renderHookProbe([]);
+
+    expect(getLatest().selectedLeagues).toEqual([
+      { name: "Premier League", code: "eng.1" },
+      { name: "Championship", code: "eng.2" },
+    ]);
+
+    renderer.unmount();
+  });
+
+  it("seeds selectedLeagues from stored default leagues when provided", () => {
+    const { renderer, getLatest } = renderHookProbe([BUNDESLIGA]);
+
+    expect(getLatest().selectedLeagues).toEqual([BUNDESLIGA]);
+
+    renderer.unmount();
+  });
+
+  it("toggleLeague (via handleLeagueChange) adds an unselected league and removes a selected one", () => {
+    const { renderer, getLatest } = renderHookProbe([PREMIER_LEAGUE]);
+
+    TestRenderer.act(() => {
+      getLatest().handleLeagueChange(CHAMPIONSHIP);
+    });
+    expect(getLatest().selectedLeagues).toEqual([PREMIER_LEAGUE, CHAMPIONSHIP]);
+
+    TestRenderer.act(() => {
+      getLatest().handleLeagueChange(PREMIER_LEAGUE);
+    });
+    expect(getLatest().selectedLeagues).toEqual([CHAMPIONSHIP]);
+
+    renderer.unmount();
+  });
+
+  it("setSelectedDate updates selectedDate", () => {
+    const { renderer, getLatest } = renderHookProbe();
+
+    TestRenderer.act(() => {
+      getLatest().setSelectedDate("2026-03-14");
+    });
+
+    expect(getLatest().selectedDate).toBe("2026-03-14");
+
+    renderer.unmount();
+  });
+
+  it("setStartTime and setEndTime update the time range independently", () => {
+    const { renderer, getLatest } = renderHookProbe();
+
+    TestRenderer.act(() => {
+      getLatest().setStartTime("12:00");
+    });
+    expect(getLatest().startTime).toBe("12:00");
+    expect(getLatest().endTime).toBe("16:00");
+
+    TestRenderer.act(() => {
+      getLatest().setEndTime("18:30");
+    });
+    expect(getLatest().endTime).toBe("18:30");
+
+    renderer.unmount();
+  });
+
+  it("syncSelectedLeagues (syncLeagues) replaces the entire selection", () => {
+    const { renderer, getLatest } = renderHookProbe([PREMIER_LEAGUE]);
+
+    TestRenderer.act(() => {
+      getLatest().syncSelectedLeagues([CHAMPIONSHIP, BUNDESLIGA]);
+    });
+
+    expect(getLatest().selectedLeagues).toEqual([CHAMPIONSHIP, BUNDESLIGA]);
+
+    renderer.unmount();
+  });
+
+  it("addCustomHomeTeam (addCustomTeam) appends a home-side team option built from the current selection", () => {
+    const { renderer, getLatest } = renderHookProbe([PREMIER_LEAGUE]);
+    const initialCount = getLatest().homeTeamOptions.length;
+
+    TestRenderer.act(() => {
+      getLatest().addCustomHomeTeam("My Custom FC");
+    });
+
+    const homeNames = getLatest().homeTeamOptions.map((t) => t.value);
+    expect(getLatest().homeTeamOptions).toHaveLength(initialCount + 1);
+    expect(homeNames).toContain("My Custom FC");
+    // Custom teams also flow into the away side, since both derive from teamOptions
+    expect(
+      getLatest().awayTeamOptions.map((t) => t.value),
+    ).toContain("My Custom FC");
+
+    renderer.unmount();
+  });
+
+  it("addCustomAwayTeam derives the custom team's league from the first selected league", () => {
+    const { renderer, getLatest } = renderHookProbe([BUNDESLIGA]);
+
+    TestRenderer.act(() => {
+      getLatest().addCustomAwayTeam("Wildcard United");
+    });
+
+    const wildcard = getLatest().awayTeamOptions.find(
+      (t) => t.value === "Wildcard United",
+    );
+    expect(wildcard?.league).toBe("Bundesliga");
+
+    renderer.unmount();
+  });
+
+  it("derives isDateFilterActive/isTimeFilterActive from current state", () => {
+    const { renderer, getLatest } = renderHookProbe();
+
+    expect(getLatest().isDateFilterActive).toBe(true);
+    expect(getLatest().isTimeFilterActive).toBe(true);
+
+    renderer.unmount();
+  });
+
+  it("cleans FC-style prefixes/suffixes when building team display names", () => {
+    const { renderer, getLatest } = renderHookProbe([PREMIER_LEAGUE], [
+      { key: "arsenal", value: "Arsenal FC", league: "Premier League" },
+    ]);
+
+    const arsenal = getLatest().homeTeamOptions.find(
+      (t) => t.value === "Arsenal FC",
+    );
+    expect(arsenal?.displayName).toBe("Arsenal");
+
+    renderer.unmount();
+  });
+});

--- a/__tests__/hooks/usePersistedTeamLogos.test.ts
+++ b/__tests__/hooks/usePersistedTeamLogos.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import React from "react";
+import TestRenderer from "react-test-renderer";
+
+import { usePersistedTeamLogos } from "../../hooks/usePersistedTeamLogos";
+import { useGameStore, type Match } from "../../store/store";
+import {
+  cacheTeamLogo,
+  clearOverriddenLogos,
+  getHardcodedTeamLogoOnly,
+  getTeamLogo,
+} from "../../utils/teamLogos";
+
+jest.mock("../../utils/teamLogos", () => ({
+  cacheTeamLogo: jest.fn(),
+  clearOverriddenLogos: jest.fn(),
+  getHardcodedTeamLogoOnly: jest.fn(),
+  getTeamLogo: jest.fn(),
+}));
+
+const mockCacheTeamLogo = jest.mocked(cacheTeamLogo);
+const mockClearOverriddenLogos = jest.mocked(clearOverriddenLogos);
+const mockGetHardcodedTeamLogoOnly = jest.mocked(getHardcodedTeamLogoOnly);
+const mockGetTeamLogo = jest.mocked(getTeamLogo);
+
+const buildMatch = (overrides: Partial<Match> = {}): Match => ({
+  id: "match-1",
+  homeTeam: "Arsenal FC",
+  awayTeam: "Chelsea FC",
+  homeGoals: 0,
+  awayGoals: 0,
+  ...overrides,
+});
+
+const setMatches = (matches: Match[]) => {
+  useGameStore.setState({ matches });
+};
+
+const renderProbe = () => {
+  const Probe = () => {
+    usePersistedTeamLogos();
+    return null;
+  };
+
+  return TestRenderer.create(React.createElement(Probe));
+};
+
+describe("usePersistedTeamLogos", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setMatches([]);
+  });
+
+  it("does nothing when there are no matches", async () => {
+    const renderer = renderProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockClearOverriddenLogos).not.toHaveBeenCalled();
+    expect(mockGetTeamLogo).not.toHaveBeenCalled();
+
+    renderer.unmount();
+  });
+
+  it("clears overridden logos and loads persisted logos for teams without hardcoded assets", async () => {
+    mockGetHardcodedTeamLogoOnly.mockReturnValue(null);
+    mockGetTeamLogo.mockImplementation(async (teamName: string) =>
+      teamName === "Arsenal FC" ? "https://example.com/arsenal.png" : null,
+    );
+    setMatches([buildMatch()]);
+
+    const renderer = renderProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockClearOverriddenLogos).toHaveBeenCalledTimes(1);
+    expect(mockGetTeamLogo).toHaveBeenCalledWith("Arsenal FC");
+    expect(mockGetTeamLogo).toHaveBeenCalledWith("Chelsea FC");
+    expect(mockCacheTeamLogo).toHaveBeenCalledWith(
+      "Arsenal FC",
+      "https://example.com/arsenal.png",
+    );
+    expect(mockCacheTeamLogo).not.toHaveBeenCalledWith(
+      "Chelsea FC",
+      expect.anything(),
+    );
+
+    renderer.unmount();
+  });
+
+  it("skips the AsyncStorage lookup for teams that already have a hardcoded logo", async () => {
+    mockGetHardcodedTeamLogoOnly.mockImplementation((teamName: string) =>
+      teamName === "Arsenal FC" ? ({} as never) : null,
+    );
+    mockGetTeamLogo.mockResolvedValue(null);
+    setMatches([buildMatch()]);
+
+    const renderer = renderProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockGetTeamLogo).not.toHaveBeenCalledWith("Arsenal FC");
+    expect(mockGetTeamLogo).toHaveBeenCalledWith("Chelsea FC");
+
+    renderer.unmount();
+  });
+
+  it("deduplicates identical home/away team names across matches", async () => {
+    mockGetHardcodedTeamLogoOnly.mockReturnValue(null);
+    mockGetTeamLogo.mockResolvedValue(null);
+    setMatches([
+      buildMatch({ id: "match-1" }),
+      buildMatch({ id: "match-2", awayTeam: "Arsenal FC" }),
+    ]);
+
+    const renderer = renderProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockGetTeamLogo).toHaveBeenCalledTimes(2);
+
+    renderer.unmount();
+  });
+
+  it("logs and continues when a persisted lookup rejects", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    mockGetHardcodedTeamLogoOnly.mockReturnValue(null);
+    mockGetTeamLogo.mockImplementation(async (teamName: string) => {
+      if (teamName === "Arsenal FC") {
+        throw new Error("storage unavailable");
+      }
+      return null;
+    });
+    setMatches([buildMatch()]);
+
+    const renderer = renderProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(mockGetTeamLogo).toHaveBeenCalledWith("Chelsea FC");
+
+    consoleErrorSpy.mockRestore();
+    renderer.unmount();
+  });
+});

--- a/__tests__/hooks/usePlayerSuggestions.test.ts
+++ b/__tests__/hooks/usePlayerSuggestions.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import React from "react";
+import TestRenderer from "react-test-renderer";
+
+import {
+  usePlayerSuggestions,
+  type PlayerSuggestion,
+} from "../../hooks/usePlayerSuggestions";
+import { useGameStore } from "../../store/store";
+
+interface HistoryGamePlayer {
+  id: string;
+  name: string;
+  drinksTaken?: number;
+}
+
+const buildGame = (
+  date: string,
+  players: HistoryGamePlayer[],
+  overrides: Partial<{
+    id: string;
+    matches: unknown[];
+    commonMatchId: string | null;
+    playerAssignments: Record<string, string[]>;
+    matchesPerPlayer: number;
+  }> = {},
+) => ({
+  id: overrides.id ?? `game-${date}`,
+  date,
+  players,
+  matches: overrides.matches ?? [],
+  commonMatchId: overrides.commonMatchId ?? null,
+  playerAssignments: overrides.playerAssignments ?? {},
+  matchesPerPlayer: overrides.matchesPerPlayer ?? 1,
+});
+
+const setHistory = (history: ReturnType<typeof buildGame>[]) => {
+  useGameStore.setState({ history: history as never });
+};
+
+const renderHookProbe = (searchQuery: string) => {
+  let latest:
+    | { playerSuggestions: PlayerSuggestion[]; hasHistory: boolean }
+    | undefined;
+
+  const Probe = () => {
+    latest = usePlayerSuggestions(searchQuery);
+    return null;
+  };
+
+  const renderer = TestRenderer.create(React.createElement(Probe));
+
+  return { renderer, getLatest: () => latest };
+};
+
+describe("usePlayerSuggestions", () => {
+  beforeEach(() => {
+    setHistory([]);
+  });
+
+  it("reports no history and empty suggestions when the game log is empty", () => {
+    const { renderer, getLatest } = renderHookProbe("");
+
+    expect(getLatest()?.hasHistory).toBe(false);
+    expect(getLatest()?.playerSuggestions).toEqual([]);
+
+    renderer.unmount();
+  });
+
+  it("aggregates games played, total drinks, and average across multiple sessions", () => {
+    setHistory([
+      buildGame("2026-01-01T00:00:00.000Z", [
+        { id: "p1", name: "Alice", drinksTaken: 4 },
+      ]),
+      buildGame("2026-01-08T00:00:00.000Z", [
+        { id: "p1", name: "Alice", drinksTaken: 2 },
+      ]),
+    ]);
+
+    const { renderer, getLatest } = renderHookProbe("");
+
+    const alice = getLatest()?.playerSuggestions.find(
+      (player) => player.name === "Alice",
+    );
+
+    expect(alice).toMatchObject({
+      gamesPlayed: 2,
+      totalDrinks: 6,
+      averageDrinksPerGame: 3,
+      lastPlayed: "2026-01-08T00:00:00.000Z",
+    });
+
+    renderer.unmount();
+  });
+
+  it("sorts by descending average drinks per game", () => {
+    setHistory([
+      buildGame("2026-01-01T00:00:00.000Z", [
+        { id: "p1", name: "LightDrinker", drinksTaken: 1 },
+        { id: "p2", name: "HeavyDrinker", drinksTaken: 9 },
+      ]),
+    ]);
+
+    const { renderer, getLatest } = renderHookProbe("");
+    const names = getLatest()?.playerSuggestions.map((player) => player.name);
+
+    expect(names).toEqual(["HeavyDrinker", "LightDrinker"]);
+
+    renderer.unmount();
+  });
+
+  it("breaks near-equal averages by most recent play date", () => {
+    setHistory([
+      buildGame("2026-01-01T00:00:00.000Z", [
+        { id: "p1", name: "Older", drinksTaken: 3 },
+      ]),
+      buildGame("2026-02-01T00:00:00.000Z", [
+        { id: "p2", name: "Newer", drinksTaken: 3 },
+      ]),
+    ]);
+
+    const { renderer, getLatest } = renderHookProbe("");
+    const names = getLatest()?.playerSuggestions.map((player) => player.name);
+
+    expect(names).toEqual(["Newer", "Older"]);
+
+    renderer.unmount();
+  });
+
+  it("filters suggestions case-insensitively by the search query", () => {
+    setHistory([
+      buildGame("2026-01-01T00:00:00.000Z", [
+        { id: "p1", name: "Alice", drinksTaken: 1 },
+        { id: "p2", name: "Bob", drinksTaken: 1 },
+      ]),
+    ]);
+
+    const { renderer, getLatest } = renderHookProbe("ali");
+    const names = getLatest()?.playerSuggestions.map((player) => player.name);
+
+    expect(names).toEqual(["Alice"]);
+
+    renderer.unmount();
+  });
+
+  it("caps suggestions at 6 players", () => {
+    setHistory([
+      buildGame(
+        "2026-01-01T00:00:00.000Z",
+        Array.from({ length: 8 }, (_, index) => ({
+          id: `p${index}`,
+          name: `Player${index}`,
+          drinksTaken: index,
+        })),
+      ),
+    ]);
+
+    const { renderer, getLatest } = renderHookProbe("");
+
+    expect(getLatest()?.playerSuggestions).toHaveLength(6);
+
+    renderer.unmount();
+  });
+
+  it("defaults missing drinksTaken to zero", () => {
+    setHistory([
+      buildGame("2026-01-01T00:00:00.000Z", [{ id: "p1", name: "Alice" }]),
+    ]);
+
+    const { renderer, getLatest } = renderHookProbe("");
+    const alice = getLatest()?.playerSuggestions.find(
+      (player) => player.name === "Alice",
+    );
+
+    expect(alice).toMatchObject({ totalDrinks: 0, averageDrinksPerGame: 0 });
+
+    renderer.unmount();
+  });
+});

--- a/__tests__/hooks/useTeamLogo.test.ts
+++ b/__tests__/hooks/useTeamLogo.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import React from "react";
+import { ImageSourcePropType } from "react-native";
+import TestRenderer from "react-test-renderer";
+
+import { useTeamLogo } from "../../hooks/useTeamLogo";
+import { getHardcodedTeamLogoOnly, getTeamLogo } from "../../utils/teamLogos";
+
+jest.mock("../../utils/teamLogos", () => ({
+  getHardcodedTeamLogoOnly: jest.fn(),
+  getTeamLogo: jest.fn(),
+}));
+
+const mockGetHardcodedTeamLogoOnly = jest.mocked(getHardcodedTeamLogoOnly);
+const mockGetTeamLogo = jest.mocked(getTeamLogo);
+
+const DEFAULT_LOGO = require("../../assets/images/teams/default.png");
+const HARDCODED_LOGO = { testUri: "hardcoded-arsenal" } as ImageSourcePropType;
+
+const renderHookProbe = (teamName: string) => {
+  const observedSources: ImageSourcePropType[] = [];
+  let latest: ImageSourcePropType | undefined;
+
+  const Probe = () => {
+    latest = useTeamLogo(teamName);
+    observedSources.push(latest);
+    return null;
+  };
+
+  const renderer = TestRenderer.create(React.createElement(Probe));
+
+  return { renderer, observedSources, getLatest: () => latest };
+};
+
+describe("useTeamLogo", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns the default logo immediately for an empty team name", () => {
+    const { renderer, getLatest } = renderHookProbe("");
+
+    expect(getLatest()).toBe(DEFAULT_LOGO);
+    expect(mockGetHardcodedTeamLogoOnly).not.toHaveBeenCalled();
+
+    renderer.unmount();
+  });
+
+  it("returns the default logo immediately for a whitespace-only team name", () => {
+    const { renderer, getLatest } = renderHookProbe("   ");
+
+    expect(getLatest()).toBe(DEFAULT_LOGO);
+
+    renderer.unmount();
+  });
+
+  it("returns a hardcoded logo synchronously without checking the async cache", async () => {
+    mockGetHardcodedTeamLogoOnly.mockReturnValue(HARDCODED_LOGO);
+
+    const { renderer, getLatest } = renderHookProbe("Arsenal FC");
+
+    expect(getLatest()).toBe(HARDCODED_LOGO);
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getLatest()).toBe(HARDCODED_LOGO);
+    expect(mockGetTeamLogo).not.toHaveBeenCalled();
+
+    renderer.unmount();
+  });
+
+  it("falls back to the default logo, then updates to the persisted API logo", async () => {
+    mockGetHardcodedTeamLogoOnly.mockReturnValue(null);
+    mockGetTeamLogo.mockResolvedValue("https://example.com/logo.png");
+
+    const { renderer, getLatest } = renderHookProbe("Unmapped United");
+
+    expect(getLatest()).toBe(DEFAULT_LOGO);
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getLatest()).toEqual({ uri: "https://example.com/logo.png" });
+
+    renderer.unmount();
+  });
+
+  it("stays on the default logo when no persisted logo is found", async () => {
+    mockGetHardcodedTeamLogoOnly.mockReturnValue(null);
+    mockGetTeamLogo.mockResolvedValue(null);
+
+    const { renderer, getLatest } = renderHookProbe("Unmapped United");
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getLatest()).toBe(DEFAULT_LOGO);
+
+    renderer.unmount();
+  });
+
+  it("logs and keeps the default logo when the persisted lookup rejects", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    mockGetHardcodedTeamLogoOnly.mockReturnValue(null);
+    mockGetTeamLogo.mockRejectedValue(new Error("storage unavailable"));
+
+    const { renderer, getLatest } = renderHookProbe("Unmapped United");
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getLatest()).toBe(DEFAULT_LOGO);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+    renderer.unmount();
+  });
+
+  it("re-resolves the logo when the team name changes", async () => {
+    mockGetHardcodedTeamLogoOnly.mockImplementation((teamName: string) =>
+      teamName === "Chelsea FC" ? HARDCODED_LOGO : null,
+    );
+    mockGetTeamLogo.mockResolvedValue(null);
+
+    let teamName = "Unmapped United";
+    let latest: ImageSourcePropType | undefined;
+
+    const Probe = () => {
+      latest = useTeamLogo(teamName);
+      return null;
+    };
+
+    const renderer = TestRenderer.create(React.createElement(Probe));
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(latest).toBe(DEFAULT_LOGO);
+
+    teamName = "Chelsea FC";
+    await TestRenderer.act(async () => {
+      renderer.update(React.createElement(Probe));
+    });
+
+    expect(latest).toBe(HARDCODED_LOGO);
+
+    renderer.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
Adds unit tests for 5 previously-untested hooks, using the project's established `react-test-renderer` + Probe-component pattern (this repo doesn't depend on `@testing-library/react-native`):

- `useTeamLogo.test.ts` (7 tests) — hardcoded > cached > default priority, async resolution, error handling, re-resolution on team name change
- `usePersistedTeamLogos.test.ts` (5 tests) — `clearOverriddenLogos` + AsyncStorage load side effects, hardcoded-logo skip, dedup, error handling
- `usePlayerSuggestions.test.ts` (7 tests) — stats aggregation, average-drinks sort with recency tiebreak, search filtering, 6-item cap
- `useLeagueLogo.test.ts` (6 tests) — local asset > AsyncStorage cache > ESPN API priority, unmount guard; also characterizes a pre-existing quirk where `isLoading` never resolves to `false` when there's no local asset, no cache, and no `leagueCode` (documented, not "fixed")
- `useMatchListFilters.test.ts` (10 tests) — each reducer action exercised via its exposed callback, plus derived state (team options, filter-active flags)

**T054 deferred**: the plan's `useTeamData.test.ts` (mocking `fetch` across the 7 league calls) assumes Phase 3's axios→fetch replacement (PR #171) is already in place. It isn't in this branch's lineage — Phase 3 branches independently from Phase 1 and was never stacked into the 04→06→07→08→09 chain, so `useTeamData.ts` here still imports `axios`. Writing a fetch-based test now would need rewriting once Phase 3 actually merges, so it's deferred rather than written against code that doesn't match the plan's premise.

## Test plan
- [x] Each new file green in isolation
- [x] `npx jest --ci` — 70 suites / 334 tests (was 65/299 — +5 suites/+35 tests)
- [x] `npm run lint` — 0 errors, 298 warnings (matches pre-existing baseline exactly)
- [x] `npx tsc --noEmit` — 130 errors (matches pre-existing baseline exactly)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)