### PR TITLE
test: add hook tests, complex tier (Phase 10)

### DIFF
--- a/__tests__/hooks/gameProgress/goalScoring.test.ts
+++ b/__tests__/hooks/gameProgress/goalScoring.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  applyAwayGoalUpdate,
+  applyHomeGoalUpdate,
+  calculateToastScoreDisplay,
+  updateMatchForGoal,
+} from "../../../hooks/gameProgress/goalScoring";
+import type { Match } from "../../../store/store";
+
+const buildMatch = (overrides: Partial<Match> = {}): Match => ({
+  id: "match-1",
+  homeTeam: "Arsenal FC",
+  awayTeam: "Chelsea FC",
+  homeGoals: 1,
+  awayGoals: 0,
+  ...overrides,
+});
+
+describe("calculateToastScoreDisplay", () => {
+  it("uses the live newTotal/otherTeamScore pairing for the home team", () => {
+    const result = calculateToastScoreDisplay(
+      buildMatch(),
+      "home",
+      true,
+      3,
+      2,
+    );
+
+    expect(result).toEqual({ homeScore: 3, awayScore: 2 });
+  });
+
+  it("uses the live newTotal/otherTeamScore pairing for the away team", () => {
+    const result = calculateToastScoreDisplay(
+      buildMatch(),
+      "away",
+      true,
+      3,
+      2,
+    );
+
+    expect(result).toEqual({ homeScore: 2, awayScore: 3 });
+  });
+
+  it("falls back to the match's own goal counts when not a live update", () => {
+    const result = calculateToastScoreDisplay(
+      buildMatch({ homeGoals: 4, awayGoals: 1 }),
+      "home",
+      false,
+    );
+
+    expect(result).toEqual({ homeScore: 4, awayScore: 1 });
+  });
+
+  it("falls back to the match's own goal counts when live totals are missing", () => {
+    const result = calculateToastScoreDisplay(
+      buildMatch({ homeGoals: 2, awayGoals: 2 }),
+      "home",
+      true,
+    );
+
+    expect(result).toEqual({ homeScore: 2, awayScore: 2 });
+  });
+});
+
+describe("applyHomeGoalUpdate", () => {
+  it("manual increment (no newTotal) bumps homeGoals by one and reports a goal", () => {
+    const result = applyHomeGoalUpdate(buildMatch({ homeGoals: 1 }));
+
+    expect(result.updatedMatch.homeGoals).toBe(2);
+    expect(result.goalScored).toBe(true);
+    expect(result.scoringTeamTotal).toBeUndefined();
+  });
+
+  it("live update with a higher newTotal counts as a goal and carries the other team's score", () => {
+    const result = applyHomeGoalUpdate(
+      buildMatch({ homeGoals: 1, awayGoals: 3 }),
+      2,
+    );
+
+    expect(result.updatedMatch.homeGoals).toBe(2);
+    expect(result.goalScored).toBe(true);
+    expect(result.scoringTeamTotal).toBe(2);
+    expect(result.otherTeamScore).toBe(3);
+  });
+
+  it("live update with an unchanged newTotal reports no goal", () => {
+    const result = applyHomeGoalUpdate(buildMatch({ homeGoals: 2 }), 2);
+
+    expect(result.updatedMatch.homeGoals).toBe(2);
+    expect(result.goalScored).toBe(false);
+  });
+
+  it("live update with a lower newTotal (correction) applies it without a goal", () => {
+    const result = applyHomeGoalUpdate(buildMatch({ homeGoals: 3 }), 1);
+
+    expect(result.updatedMatch.homeGoals).toBe(1);
+    expect(result.goalScored).toBe(false);
+  });
+});
+
+describe("applyAwayGoalUpdate", () => {
+  it("manual increment bumps awayGoals by one and reports a goal", () => {
+    const result = applyAwayGoalUpdate(buildMatch({ awayGoals: 0 }));
+
+    expect(result.updatedMatch.awayGoals).toBe(1);
+    expect(result.goalScored).toBe(true);
+  });
+
+  it("live update with a higher newTotal carries the home team's score as otherTeamScore", () => {
+    const result = applyAwayGoalUpdate(
+      buildMatch({ homeGoals: 5, awayGoals: 0 }),
+      1,
+    );
+
+    expect(result.updatedMatch.awayGoals).toBe(1);
+    expect(result.goalScored).toBe(true);
+    expect(result.otherTeamScore).toBe(5);
+  });
+});
+
+describe("updateMatchForGoal", () => {
+  it("produces goalInfo with a timestamp when a home goal is scored manually", () => {
+    const before = Date.now();
+    const { updatedMatch, goalInfo } = updateMatchForGoal(
+      buildMatch({ homeGoals: 1 }),
+      "home",
+    );
+
+    expect(updatedMatch.homeGoals).toBe(2);
+    expect(goalInfo).not.toBeNull();
+    expect(goalInfo?.team).toBe("home");
+    expect(goalInfo?.isLiveUpdate).toBe(false);
+    expect(goalInfo?.timestamp).toBeGreaterThanOrEqual(before);
+  });
+
+  it("produces goalInfo for a live away goal with newTotal/otherTeamScore populated", () => {
+    const { goalInfo } = updateMatchForGoal(
+      buildMatch({ homeGoals: 1, awayGoals: 0 }),
+      "away",
+      1,
+    );
+
+    expect(goalInfo?.isLiveUpdate).toBe(true);
+    expect(goalInfo?.newTotal).toBe(1);
+    expect(goalInfo?.otherTeamScore).toBe(1);
+  });
+
+  it("returns null goalInfo when the update is a correction, not a goal", () => {
+    const { updatedMatch, goalInfo } = updateMatchForGoal(
+      buildMatch({ homeGoals: 3 }),
+      "home",
+      3,
+    );
+
+    expect(updatedMatch.homeGoals).toBe(3);
+    expect(goalInfo).toBeNull();
+  });
+});

--- a/__tests__/hooks/gameProgress/matchMigration.test.ts
+++ b/__tests__/hooks/gameProgress/matchMigration.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { migrateLegacyMatch } from "../../../hooks/gameProgress/matchMigration";
+import type { Match } from "../../../store/store";
+
+const buildMatch = (overrides: Partial<Match> = {}): Match => ({
+  id: "match-1",
+  homeTeam: "Arsenal FC",
+  awayTeam: "Chelsea FC",
+  homeGoals: 0,
+  awayGoals: 0,
+  ...overrides,
+});
+
+describe("migrateLegacyMatch", () => {
+  it("splits a legacy total goals value evenly for an even total", () => {
+    const match = buildMatch({
+      homeGoals: undefined,
+      awayGoals: undefined,
+      goals: 4,
+    });
+
+    const migrated = migrateLegacyMatch(match);
+
+    expect(migrated.homeGoals).toBe(2);
+    expect(migrated.awayGoals).toBe(2);
+  });
+
+  it("floors home and ceils away for an odd legacy total", () => {
+    const match = buildMatch({
+      homeGoals: undefined,
+      awayGoals: undefined,
+      goals: 5,
+    });
+
+    const migrated = migrateLegacyMatch(match);
+
+    expect(migrated.homeGoals).toBe(2);
+    expect(migrated.awayGoals).toBe(3);
+  });
+
+  it("only migrates from goals when a per-team field is actually missing", () => {
+    const match = buildMatch({ homeGoals: 3, awayGoals: 1, goals: 4 });
+
+    const migrated = migrateLegacyMatch(match);
+
+    expect(migrated.homeGoals).toBe(3);
+    expect(migrated.awayGoals).toBe(1);
+  });
+
+  it("defaults undefined per-team goals to 0 when there is no legacy total", () => {
+    const match = buildMatch({ homeGoals: undefined, awayGoals: undefined });
+
+    const migrated = migrateLegacyMatch(match);
+
+    expect(migrated.homeGoals).toBe(0);
+    expect(migrated.awayGoals).toBe(0);
+  });
+
+  it("leaves an already-migrated match with both fields set unchanged", () => {
+    const match = buildMatch({ homeGoals: 2, awayGoals: 1 });
+
+    const migrated = migrateLegacyMatch(match);
+
+    expect(migrated).toEqual(match);
+  });
+});

--- a/__tests__/hooks/gameProgress/toastQueueReducer.test.ts
+++ b/__tests__/hooks/gameProgress/toastQueueReducer.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  initialToastQueueState,
+  toastQueueReducer,
+  type QueuedToastData,
+  type ToastQueueState,
+} from "../../../hooks/gameProgress/toastQueueReducer";
+
+const buildToast = (
+  overrides: Partial<QueuedToastData> = {},
+): QueuedToastData => ({
+  type: "success",
+  text1: "Arsenal 1-0 Chelsea",
+  text2: "Alice should drink!",
+  ...overrides,
+});
+
+describe("toastQueueReducer", () => {
+  it("enqueue appends to the queue without affecting visibility", () => {
+    const toast = buildToast();
+    const next = toastQueueReducer(initialToastQueueState, {
+      type: "enqueue",
+      toast,
+    });
+
+    expect(next.queue).toEqual([toast]);
+    expect(next.isToastVisible).toBe(false);
+  });
+
+  it("enqueue preserves FIFO order across multiple calls", () => {
+    const first = buildToast({ text1: "first" });
+    const second = buildToast({ text1: "second" });
+
+    const afterFirst = toastQueueReducer(initialToastQueueState, {
+      type: "enqueue",
+      toast: first,
+    });
+    const afterSecond = toastQueueReducer(afterFirst, {
+      type: "enqueue",
+      toast: second,
+    });
+
+    expect(afterSecond.queue).toEqual([first, second]);
+  });
+
+  it("showNext pops the front of the queue and marks a toast visible", () => {
+    const first = buildToast({ text1: "first" });
+    const second = buildToast({ text1: "second" });
+    const state: ToastQueueState = {
+      queue: [first, second],
+      isToastVisible: false,
+    };
+
+    const next = toastQueueReducer(state, { type: "showNext" });
+
+    expect(next.queue).toEqual([second]);
+    expect(next.isToastVisible).toBe(true);
+  });
+
+  it("hide clears visibility without touching the queue", () => {
+    const state: ToastQueueState = {
+      queue: [buildToast()],
+      isToastVisible: true,
+    };
+
+    const next = toastQueueReducer(state, { type: "hide" });
+
+    expect(next.isToastVisible).toBe(false);
+    expect(next.queue).toEqual(state.queue);
+  });
+
+  it("returns the same state reference for an unknown action", () => {
+    const next = toastQueueReducer(
+      initialToastQueueState,
+      { type: "noop" } as any,
+    );
+
+    expect(next).toBe(initialToastQueueState);
+  });
+});

--- a/__tests__/hooks/gameProgress/uiReducer.test.ts
+++ b/__tests__/hooks/gameProgress/uiReducer.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  gameProgressUiReducer,
+  initialGameProgressUiState,
+  type GameProgressUiState,
+} from "../../../hooks/gameProgress/uiReducer";
+
+describe("gameProgressUiReducer", () => {
+  it("setActiveTab switches the active tab", () => {
+    const next = gameProgressUiReducer(initialGameProgressUiState, {
+      type: "setActiveTab",
+      tab: "players",
+    });
+
+    expect(next.activeTab).toBe("players");
+  });
+
+  it("setAlertVisible toggles the alert flag", () => {
+    const next = gameProgressUiReducer(initialGameProgressUiState, {
+      type: "setAlertVisible",
+      visible: true,
+    });
+
+    expect(next.isAlertVisible).toBe(true);
+  });
+
+  it("openQuickActions sets the selected match and shows the modal", () => {
+    const next = gameProgressUiReducer(initialGameProgressUiState, {
+      type: "openQuickActions",
+      matchId: "match-1",
+    });
+
+    expect(next.selectedMatchId).toBe("match-1");
+    expect(next.isQuickActionsVisible).toBe(true);
+  });
+
+  it("closeQuickActions clears the selected match and hides the modal", () => {
+    const openState: GameProgressUiState = {
+      ...initialGameProgressUiState,
+      selectedMatchId: "match-1",
+      isQuickActionsVisible: true,
+    };
+
+    const next = gameProgressUiReducer(openState, {
+      type: "closeQuickActions",
+    });
+
+    expect(next.selectedMatchId).toBeNull();
+    expect(next.isQuickActionsVisible).toBe(false);
+  });
+
+  it("setRefreshing toggles the refreshing flag", () => {
+    const next = gameProgressUiReducer(initialGameProgressUiState, {
+      type: "setRefreshing",
+      refreshing: true,
+    });
+
+    expect(next.refreshing).toBe(true);
+  });
+
+  it("returns the same state reference for an unknown action", () => {
+    const next = gameProgressUiReducer(
+      initialGameProgressUiState,
+      { type: "noop" } as any,
+    );
+
+    expect(next).toBe(initialGameProgressUiState);
+  });
+});

--- a/__tests__/hooks/useGameProgressController.test.ts
+++ b/__tests__/hooks/useGameProgressController.test.ts
@@ -1,0 +1,333 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import React from "react";
+import Toast from "react-native-toast-message";
+import TestRenderer from "react-test-renderer";
+
+import useGameProgressController from "../../hooks/useGameProgressController";
+import { useLiveScores } from "../../hooks/useLiveScores";
+import { useAppVisibility, useGoalSound } from "../../platform";
+import { useGameStore } from "../../store/store";
+
+jest.mock("react-native-toast-message", () => ({
+  __esModule: true,
+  default: { show: jest.fn() },
+}));
+
+jest.mock("../../hooks/useLiveScores", () => ({
+  useLiveScores: jest.fn(),
+}));
+
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+
+jest.mock("expo-router", () => ({
+  useRouter: jest.fn(() => ({ push: mockPush, replace: mockReplace })),
+}));
+
+jest.mock("../../platform", () => ({
+  useAppVisibility: jest.fn(),
+  useGoalSound: jest.fn(),
+}));
+
+const mockUseLiveScores = jest.mocked(useLiveScores);
+const mockUseAppVisibility = jest.mocked(useAppVisibility);
+const mockUseGoalSound = jest.mocked(useGoalSound);
+const mockToastShow = jest.mocked(Toast.show);
+
+const startPolling = jest.fn();
+const stopPolling = jest.fn();
+const fetchCurrentScores = jest.fn(async () => undefined);
+const playGoalSound = jest.fn(async () => true);
+
+type Controller = ReturnType<typeof useGameProgressController>;
+
+const renderControllerProbe = () => {
+  let latest: Controller | undefined;
+
+  const Probe = () => {
+    latest = useGameProgressController();
+    return null;
+  };
+
+  const renderer = TestRenderer.create(React.createElement(Probe));
+
+  return { renderer, getLatest: () => latest as Controller };
+};
+
+describe("useGameProgressController (integration)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseLiveScores.mockReturnValue({
+      liveMatches: [],
+      isPolling: false,
+      lastUpdated: null,
+      startPolling,
+      stopPolling,
+      fetchCurrentScores,
+    });
+    mockUseAppVisibility.mockReturnValue({
+      snapshot: {
+        state: "active",
+        source: "appState",
+        isInteractive: true,
+        capturedAt: Date.now(),
+      },
+      visibilityState: "active",
+      isInteractive: true,
+    });
+    mockUseGoalSound.mockReturnValue({
+      isSoundPlaying: false,
+      playGoalSound,
+      stopGoalSound: jest.fn(async () => undefined),
+    });
+
+    useGameStore.setState({
+      players: [
+        { id: "p1", name: "Alice", drinksTaken: 0 },
+        { id: "p2", name: "Bob", drinksTaken: 0 },
+      ],
+      matches: [
+        {
+          id: "m1",
+          homeTeam: "Arsenal FC",
+          awayTeam: "Chelsea FC",
+          homeGoals: 0,
+          awayGoals: 0,
+        },
+      ],
+      commonMatchId: "m1",
+      playerAssignments: {},
+      soundEnabled: true,
+      commonMatchNotificationsEnabled: true,
+    });
+  });
+
+  it("migrates legacy goals-only matches into homeGoals/awayGoals on mount", async () => {
+    useGameStore.setState({
+      matches: [
+        {
+          id: "legacy-1",
+          homeTeam: "Arsenal FC",
+          awayTeam: "Chelsea FC",
+          homeGoals: undefined as unknown as number,
+          awayGoals: undefined as unknown as number,
+          goals: 5,
+        },
+      ],
+    });
+
+    const { renderer, getLatest } = renderControllerProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+    });
+
+    const migrated = getLatest().matches.find((m) => m.id === "legacy-1");
+    expect(migrated?.homeGoals).toBe(2);
+    expect(migrated?.awayGoals).toBe(3);
+
+    await TestRenderer.act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  it("starts polling when matches exist and stops polling on unmount", async () => {
+    const { renderer } = renderControllerProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(startPolling).toHaveBeenCalled();
+    expect(stopPolling).not.toHaveBeenCalled();
+
+    await TestRenderer.act(async () => {
+      renderer.unmount();
+    });
+
+    expect(stopPolling).toHaveBeenCalled();
+  });
+
+  it("handleGoalIncrement updates the match, plays the goal sound, and shows a toast for the common match", async () => {
+    const { renderer, getLatest } = renderControllerProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+    });
+
+    await TestRenderer.act(async () => {
+      getLatest().handleGoalIncrement("m1", "home");
+      await Promise.resolve();
+    });
+
+    const updated = getLatest().matches.find((m) => m.id === "m1");
+    expect(updated?.homeGoals).toBe(1);
+    expect(playGoalSound).toHaveBeenCalledTimes(1);
+    expect(mockToastShow).toHaveBeenCalledTimes(1);
+
+    const [payload] = mockToastShow.mock.calls[0] as [{ text2: string }];
+    // m1 is the common match, so both Alice and Bob should be listed.
+    expect(payload.text2).toBe("Alice, Bob should drink!");
+
+    await TestRenderer.act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  it("suppresses the goal notification for the common match when commonMatchNotificationsEnabled is false", async () => {
+    useGameStore.setState({ commonMatchNotificationsEnabled: false });
+
+    const { renderer, getLatest } = renderControllerProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+    });
+
+    await TestRenderer.act(async () => {
+      getLatest().handleGoalIncrement("m1", "home");
+      await Promise.resolve();
+    });
+
+    expect(playGoalSound).not.toHaveBeenCalled();
+    expect(mockToastShow).not.toHaveBeenCalled();
+    // The score itself still updates -- only the notification is suppressed.
+    expect(getLatest().matches.find((m) => m.id === "m1")?.homeGoals).toBe(1);
+
+    await TestRenderer.act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  it("handleGoalDecrement never takes a team's goals below zero", async () => {
+    const { renderer, getLatest } = renderControllerProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+    });
+
+    await TestRenderer.act(async () => {
+      getLatest().handleGoalDecrement("m1", "home");
+    });
+
+    expect(getLatest().matches.find((m) => m.id === "m1")?.homeGoals).toBe(0);
+
+    await TestRenderer.act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  it("handleDrinkIncrement/handleDrinkDecrement adjust a player's drinksTaken by 0.5, floored at 0", async () => {
+    const { renderer, getLatest } = renderControllerProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+    });
+
+    await TestRenderer.act(async () => {
+      getLatest().handleDrinkIncrement("p1");
+    });
+    expect(
+      getLatest().players.find((p) => p.id === "p1")?.drinksTaken,
+    ).toBe(0.5);
+
+    await TestRenderer.act(async () => {
+      getLatest().handleDrinkDecrement("p1");
+    });
+    expect(
+      getLatest().players.find((p) => p.id === "p1")?.drinksTaken,
+    ).toBe(0);
+
+    await TestRenderer.act(async () => {
+      getLatest().handleDrinkDecrement("p1");
+    });
+    expect(
+      getLatest().players.find((p) => p.id === "p1")?.drinksTaken,
+    ).toBe(0);
+
+    await TestRenderer.act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  it("onRefresh toggles refreshing around fetchCurrentScores and survives a rejection", async () => {
+    fetchCurrentScores.mockRejectedValueOnce(new Error("network error"));
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const { renderer, getLatest } = renderControllerProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+    });
+
+    await TestRenderer.act(async () => {
+      await getLatest().onRefresh();
+    });
+
+    expect(fetchCurrentScores).toHaveBeenCalledTimes(1);
+    expect(getLatest().refreshing).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+    await TestRenderer.act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  it("confirmEndGame saves history, resets state, and navigates home", async () => {
+    const { renderer, getLatest } = renderControllerProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+    });
+
+    await TestRenderer.act(async () => {
+      getLatest().handleEndGame();
+    });
+    expect(getLatest().isAlertVisible).toBe(true);
+
+    await TestRenderer.act(async () => {
+      getLatest().confirmEndGame();
+    });
+
+    expect(getLatest().isAlertVisible).toBe(false);
+    expect(mockReplace).toHaveBeenCalledWith("/");
+    // resetState clears matches/players back to empty.
+    expect(useGameStore.getState().matches).toEqual([]);
+
+    await TestRenderer.act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  it("handleBackToSetup navigates to /setupGame, and quick-actions open/close toggles UI state", async () => {
+    const { renderer, getLatest } = renderControllerProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+    });
+
+    await TestRenderer.act(async () => {
+      getLatest().handleBackToSetup();
+    });
+    expect(mockPush).toHaveBeenCalledWith("/setupGame");
+
+    await TestRenderer.act(async () => {
+      getLatest().openQuickActions("m1");
+    });
+    expect(getLatest().selectedMatchId).toBe("m1");
+    expect(getLatest().isQuickActionsVisible).toBe(true);
+
+    await TestRenderer.act(async () => {
+      getLatest().closeQuickActions();
+    });
+    expect(getLatest().selectedMatchId).toBeNull();
+    expect(getLatest().isQuickActionsVisible).toBe(false);
+
+    await TestRenderer.act(async () => {
+      renderer.unmount();
+    });
+  });
+});

--- a/__tests__/hooks/useGoalToastQueue.test.ts
+++ b/__tests__/hooks/useGoalToastQueue.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import React from "react";
+import Toast from "react-native-toast-message";
+import TestRenderer from "react-test-renderer";
+
+import { useGoalToastQueue } from "../../hooks/useGoalToastQueue";
+import type { LastGoalInfo } from "../../hooks/gameProgress/goalScoring";
+import type { Match } from "../../store/store";
+
+jest.mock("react-native-toast-message", () => ({
+  __esModule: true,
+  default: { show: jest.fn() },
+}));
+
+const mockToastShow = jest.mocked(Toast.show);
+
+const buildMatch = (overrides: Partial<Match> = {}): Match => ({
+  id: "match-1",
+  homeTeam: "Arsenal FC",
+  awayTeam: "Chelsea FC",
+  homeGoals: 1,
+  awayGoals: 0,
+  ...overrides,
+});
+
+const buildGoalInfo = (
+  overrides: Partial<LastGoalInfo> = {},
+): LastGoalInfo => ({
+  match: buildMatch(),
+  matchId: "match-1",
+  team: "home",
+  isLiveUpdate: false,
+  timestamp: Date.now(),
+  ...overrides,
+});
+
+type Hook = ReturnType<typeof useGoalToastQueue>;
+
+const renderHookProbe = (getPlayersWhoDrink: (matchId: string) => string[]) => {
+  let latest: Hook | undefined;
+
+  const Probe = () => {
+    latest = useGoalToastQueue(getPlayersWhoDrink);
+    return null;
+  };
+
+  const renderer = TestRenderer.create(React.createElement(Probe));
+
+  return { renderer, getLatest: () => latest as Hook };
+};
+
+describe("useGoalToastQueue", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows a toast with the score title and a drink message for one player", async () => {
+    const getPlayersWhoDrink = jest.fn(() => ["Alice"]);
+    const { renderer, getLatest } = renderHookProbe(getPlayersWhoDrink);
+
+    await TestRenderer.act(async () => {
+      getLatest().enqueueGoalToast(buildGoalInfo());
+      await Promise.resolve();
+    });
+
+    expect(mockToastShow).toHaveBeenCalledTimes(1);
+    const [payload] = mockToastShow.mock.calls[0] as [
+      { text1: string; text2: string },
+    ];
+    expect(payload.text1).toBe("Arsenal FC 1-0 Chelsea FC");
+    expect(payload.text2).toBe("Alice should drink!");
+
+    renderer.unmount();
+  });
+
+  it("formats the message for more than 3 affected players", async () => {
+    const getPlayersWhoDrink = jest.fn(() => [
+      "Alice",
+      "Bob",
+      "Cara",
+      "Dan",
+      "Eve",
+    ]);
+    const { renderer, getLatest } = renderHookProbe(getPlayersWhoDrink);
+
+    await TestRenderer.act(async () => {
+      getLatest().enqueueGoalToast(buildGoalInfo());
+      await Promise.resolve();
+    });
+
+    const [payload] = mockToastShow.mock.calls[0] as [{ text2: string }];
+    expect(payload.text2).toBe("Alice, Bob and 3 others should drink!");
+
+    renderer.unmount();
+  });
+
+  it("does not enqueue (or show) a toast when no players are affected", async () => {
+    const getPlayersWhoDrink = jest.fn(() => []);
+    const { renderer, getLatest } = renderHookProbe(getPlayersWhoDrink);
+
+    await TestRenderer.act(async () => {
+      getLatest().enqueueGoalToast(buildGoalInfo());
+      await Promise.resolve();
+    });
+
+    expect(mockToastShow).not.toHaveBeenCalled();
+
+    renderer.unmount();
+  });
+
+  it("shows queued toasts one at a time, advancing only after onHide fires", async () => {
+    const getPlayersWhoDrink = jest.fn(() => ["Alice"]);
+    const { renderer, getLatest } = renderHookProbe(getPlayersWhoDrink);
+
+    await TestRenderer.act(async () => {
+      getLatest().enqueueGoalToast(buildGoalInfo({ matchId: "match-1" }));
+      getLatest().enqueueGoalToast(
+        buildGoalInfo({ matchId: "match-1", team: "away" }),
+      );
+      await Promise.resolve();
+    });
+
+    // Only the first toast has been shown so far.
+    expect(mockToastShow).toHaveBeenCalledTimes(1);
+
+    const firstCall = mockToastShow.mock.calls[0][0] as {
+      onHide?: () => void;
+    };
+
+    await TestRenderer.act(async () => {
+      firstCall.onHide?.();
+      await Promise.resolve();
+    });
+
+    expect(mockToastShow).toHaveBeenCalledTimes(2);
+
+    renderer.unmount();
+  });
+
+  it("includes the scoring team in the toast props", async () => {
+    const getPlayersWhoDrink = jest.fn(() => ["Alice"]);
+    const { renderer, getLatest } = renderHookProbe(getPlayersWhoDrink);
+
+    await TestRenderer.act(async () => {
+      getLatest().enqueueGoalToast(buildGoalInfo({ team: "away" }));
+      await Promise.resolve();
+    });
+
+    const [payload] = mockToastShow.mock.calls[0] as [
+      { props?: Record<string, unknown> },
+    ];
+    expect(payload.props).toEqual({ scoringTeam: "away" });
+
+    renderer.unmount();
+  });
+});

--- a/__tests__/hooks/useLegacyHistoryImport.test.ts
+++ b/__tests__/hooks/useLegacyHistoryImport.test.ts
@@ -1,0 +1,342 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import React from "react";
+import TestRenderer from "react-test-renderer";
+
+import {
+  useLegacyHistoryImport,
+  type UseLegacyHistoryImportResult,
+} from "../../hooks/useLegacyHistoryImport";
+import { useGameStore } from "../../store/store";
+import type { ImportLegacyHistoryRpcResponse } from "../../types/legacyHistoryImport";
+import {
+  getLegacyHistoryImportRpcClient,
+  getSupabaseClient,
+  hasSupabasePublicConfig,
+} from "../../utils/supabaseClient";
+
+jest.mock("../../utils/supabaseClient", () => ({
+  getLegacyHistoryImportRpcClient: jest.fn(),
+  getSupabaseClient: jest.fn(),
+  hasSupabasePublicConfig: jest.fn(),
+}));
+
+const mockGetLegacyHistoryImportRpcClient = jest.mocked(
+  getLegacyHistoryImportRpcClient,
+);
+const mockGetSupabaseClient = jest.mocked(getSupabaseClient);
+const mockHasSupabasePublicConfig = jest.mocked(hasSupabasePublicConfig);
+
+const SESSION = {
+  id: "session-1",
+  date: "2026-01-01T00:00:00.000Z",
+  players: [{ id: "p1", name: "Alice", drinksTaken: 2 }],
+  matches: [
+    {
+      id: "m1",
+      homeTeam: "Arsenal FC",
+      awayTeam: "Chelsea FC",
+      homeGoals: 1,
+      awayGoals: 0,
+    },
+  ],
+  commonMatchId: null,
+  playerAssignments: {},
+  matchesPerPlayer: 1,
+};
+
+const setHistory = (history: (typeof SESSION)[]) => {
+  useGameStore.setState({ history: history as never });
+};
+
+const mockAuthenticatedUser = (userId = "user-1") => {
+  mockGetSupabaseClient.mockReturnValue({
+    auth: { getUser: jest.fn(async () => ({ data: { user: { id: userId } } })) },
+  } as never);
+};
+
+const mockUnauthenticatedUser = () => {
+  mockGetSupabaseClient.mockReturnValue({
+    auth: {
+      getUser: jest.fn(async () => ({
+        data: { user: null },
+        error: new Error("no session"),
+      })),
+    },
+  } as never);
+};
+
+const buildImportResponse = (
+  overrides: Partial<ImportLegacyHistoryRpcResponse> = {},
+): ImportLegacyHistoryRpcResponse => ({
+  accountId: "user-1",
+  importState: "completed",
+  claimedLocalParticipantId: "p1",
+  summary: { importedCount: 1, skippedCount: 0, failedCount: 0 },
+  sessions: [
+    {
+      sourceLocalSessionId: "session-1",
+      sourceFingerprint: "fp-1",
+      state: "imported",
+    },
+  ],
+  ...overrides,
+});
+
+const renderHookProbe = () => {
+  const phases: UseLegacyHistoryImportResult["importPhase"][] = [];
+  let latest: UseLegacyHistoryImportResult | undefined;
+
+  const Probe = () => {
+    latest = useLegacyHistoryImport();
+    phases.push(latest.importPhase);
+    return null;
+  };
+
+  const renderer = TestRenderer.create(React.createElement(Probe));
+
+  return { renderer, phases, getLatest: () => latest as UseLegacyHistoryImportResult };
+};
+
+describe("useLegacyHistoryImport", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setHistory([]);
+  });
+
+  it("starts in the checking phase, then moves to ready once auth resolves (unconfigured)", async () => {
+    mockHasSupabasePublicConfig.mockReturnValue(false);
+    setHistory([SESSION]);
+
+    const { renderer, phases, getLatest } = renderHookProbe();
+
+    expect(phases[0]).toBe("checking");
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getLatest().importPhase).toBe("ready");
+    expect(getLatest().isConfigured).toBe(false);
+    expect(getLatest().authChecked).toBe(true);
+    expect(getLatest().isAuthenticated).toBe(false);
+    expect(getLatest().availabilityReason).toBe(
+      "Supabase import is not configured for this build.",
+    );
+    expect(getLatest().canStartImport).toBe(false);
+
+    renderer.unmount();
+  });
+
+  it("reports the missing-history reason when there is no local history, regardless of config", async () => {
+    mockHasSupabasePublicConfig.mockReturnValue(true);
+    mockAuthenticatedUser();
+    setHistory([]);
+
+    const { renderer, getLatest } = renderHookProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getLatest().hasLocalHistory).toBe(false);
+    expect(getLatest().availabilityReason).toBe(
+      "No local history saved on this device yet.",
+    );
+    expect(getLatest().canStartImport).toBe(false);
+
+    renderer.unmount();
+  });
+
+  it("gates on authentication: unauthenticated + configured + has history -> ready with an auth reason", async () => {
+    mockHasSupabasePublicConfig.mockReturnValue(true);
+    mockUnauthenticatedUser();
+    setHistory([SESSION]);
+
+    const { renderer, getLatest } = renderHookProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getLatest().importPhase).toBe("ready");
+    expect(getLatest().isAuthenticated).toBe(false);
+    expect(getLatest().availabilityReason).toBe("Sign in to import this history.");
+    expect(getLatest().canStartImport).toBe(false);
+
+    renderer.unmount();
+  });
+
+  it("allows starting the import once configured, authenticated, and history/claimants exist", async () => {
+    mockHasSupabasePublicConfig.mockReturnValue(true);
+    mockAuthenticatedUser();
+    setHistory([SESSION]);
+
+    const { renderer, getLatest } = renderHookProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getLatest().claimantOptions).toHaveLength(1);
+    expect(getLatest().claimantOptions[0].name).toBe("Alice");
+    expect(getLatest().canStartImport).toBe(true);
+    expect(getLatest().availabilityReason).toBeNull();
+
+    renderer.unmount();
+  });
+
+  it("transitions checking -> ready -> importing -> completed on a successful import", async () => {
+    mockHasSupabasePublicConfig.mockReturnValue(true);
+    mockAuthenticatedUser();
+    setHistory([SESSION]);
+
+    const importLegacyHistory = jest.fn(async () => buildImportResponse());
+    mockGetLegacyHistoryImportRpcClient.mockReturnValue({
+      importLegacyHistory,
+    });
+
+    const { renderer, phases, getLatest } = renderHookProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const claimant = getLatest().claimantOptions[0];
+
+    await TestRenderer.act(async () => {
+      await getLatest().importHistory(claimant);
+    });
+
+    expect(importLegacyHistory).toHaveBeenCalledTimes(1);
+    expect(getLatest().importPhase).toBe("completed");
+    expect(getLatest().isImporting).toBe(false);
+    expect(getLatest().canStartImport).toBe(false);
+    expect(phases).toEqual(
+      expect.arrayContaining(["checking", "ready", "importing", "completed"]),
+    );
+
+    renderer.unmount();
+  });
+
+  it("transitions to failed and allows retry when the RPC rejects", async () => {
+    mockHasSupabasePublicConfig.mockReturnValue(true);
+    mockAuthenticatedUser();
+    setHistory([SESSION]);
+
+    const importLegacyHistory = jest.fn(async () => {
+      throw new Error("network unreachable");
+    });
+    mockGetLegacyHistoryImportRpcClient.mockReturnValue({
+      importLegacyHistory,
+    });
+
+    const { renderer, getLatest } = renderHookProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const claimant = getLatest().claimantOptions[0];
+
+    await TestRenderer.act(async () => {
+      await getLatest().importHistory(claimant);
+    });
+
+    expect(getLatest().importPhase).toBe("failed");
+    expect(getLatest().importError).toBe("network unreachable");
+    expect(getLatest().canRetryImport).toBe(true);
+
+    renderer.unmount();
+  });
+
+  it("importHistory short-circuits with a config error and never calls the RPC client when unconfigured", async () => {
+    mockHasSupabasePublicConfig.mockReturnValue(false);
+    setHistory([SESSION]);
+
+    const { renderer, getLatest } = renderHookProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const claimant = getLatest().claimantOptions[0];
+
+    await TestRenderer.act(async () => {
+      const result = await getLatest().importHistory(claimant);
+      expect(result).toBeNull();
+    });
+
+    expect(getLatest().importError).toBe(
+      "Supabase import is not configured for this build.",
+    );
+    expect(mockGetLegacyHistoryImportRpcClient).not.toHaveBeenCalled();
+
+    renderer.unmount();
+  });
+
+  it("importHistory short-circuits with an auth error and never calls the RPC client when unauthenticated", async () => {
+    mockHasSupabasePublicConfig.mockReturnValue(true);
+    mockUnauthenticatedUser();
+    setHistory([SESSION]);
+
+    const { renderer, getLatest } = renderHookProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const claimant = getLatest().claimantOptions[0];
+
+    await TestRenderer.act(async () => {
+      const result = await getLatest().importHistory(claimant);
+      expect(result).toBeNull();
+    });
+
+    expect(getLatest().importError).toBe("Sign in to import this history.");
+    expect(mockGetLegacyHistoryImportRpcClient).not.toHaveBeenCalled();
+
+    renderer.unmount();
+  });
+
+  it("returns the cached result without re-calling the RPC when already completed", async () => {
+    mockHasSupabasePublicConfig.mockReturnValue(true);
+    mockAuthenticatedUser();
+    setHistory([SESSION]);
+
+    const response = buildImportResponse();
+    const importLegacyHistory = jest.fn(async () => response);
+    mockGetLegacyHistoryImportRpcClient.mockReturnValue({
+      importLegacyHistory,
+    });
+
+    const { renderer, getLatest } = renderHookProbe();
+
+    await TestRenderer.act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const claimant = getLatest().claimantOptions[0];
+
+    await TestRenderer.act(async () => {
+      await getLatest().importHistory(claimant);
+    });
+
+    await TestRenderer.act(async () => {
+      const secondResult = await getLatest().importHistory(claimant);
+      expect(secondResult).toEqual(response);
+    });
+
+    expect(importLegacyHistory).toHaveBeenCalledTimes(1);
+
+    renderer.unmount();
+  });
+});

--- a/__tests__/hooks/useMatchProcessing.test.ts
+++ b/__tests__/hooks/useMatchProcessing.test.ts
@@ -1,0 +1,302 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import React, { useState } from "react";
+import TestRenderer from "react-test-renderer";
+
+import { useMatchProcessing } from "../../hooks/useMatchProcessing";
+import type { Match } from "../../store/store";
+import type { MatchData } from "../../utils/matchUtils";
+
+interface HarnessResult {
+  matches: Match[];
+  startProcessing: (filteredMatches: MatchData[]) => void;
+  isProcessing: boolean;
+  processingState: {
+    isProcessing: boolean;
+    matchesAdded: number;
+    matchesSkipped: number;
+    totalToProcess: number;
+  };
+  homeTeamCalls: string[];
+  awayTeamCalls: string[];
+}
+
+const buildMatchData = (
+  overrides: Partial<MatchData> = {},
+): MatchData => ({
+  id: "match-a",
+  team1: "Arsenal FC",
+  team2: "Chelsea FC",
+  ...overrides,
+});
+
+const buildMatch = (overrides: Partial<Match> = {}): Match => ({
+  id: "existing-1",
+  homeTeam: "Liverpool FC",
+  awayTeam: "Everton FC",
+  homeGoals: 0,
+  awayGoals: 0,
+  ...overrides,
+});
+
+const renderHarness = (
+  initialMatches: Match[],
+  setGlobalMatches?: (matches: Match[]) => void,
+) => {
+  let latest: HarnessResult | undefined;
+
+  const Harness = () => {
+    const [matches, setMatches] = useState<Match[]>(initialMatches);
+    const homeTeamCallsRef = React.useRef<string[]>([]);
+    const awayTeamCallsRef = React.useRef<string[]>([]);
+    const homeTeamRef = React.useRef("");
+    const awayTeamRef = React.useRef("");
+
+    const setHomeTeam = (team: string) => {
+      homeTeamRef.current = team;
+      homeTeamCallsRef.current.push(team);
+    };
+    const setAwayTeam = (team: string) => {
+      awayTeamRef.current = team;
+      awayTeamCallsRef.current.push(team);
+    };
+    const handleAddMatch = () => {
+      setMatches((prev) => [
+        ...prev,
+        {
+          id: `${homeTeamRef.current}-${awayTeamRef.current}`,
+          homeTeam: homeTeamRef.current,
+          awayTeam: awayTeamRef.current,
+          homeGoals: 0,
+          awayGoals: 0,
+        },
+      ]);
+    };
+
+    const hook = useMatchProcessing(
+      matches,
+      setHomeTeam,
+      setAwayTeam,
+      handleAddMatch,
+      setGlobalMatches,
+    );
+
+    latest = {
+      matches,
+      ...hook,
+      homeTeamCalls: homeTeamCallsRef.current,
+      awayTeamCalls: awayTeamCallsRef.current,
+    };
+
+    return null;
+  };
+
+  const renderer = TestRenderer.create(React.createElement(Harness));
+
+  return { renderer, getLatest: () => latest as HarnessResult };
+};
+
+describe("useMatchProcessing", () => {
+  describe("batch path (setGlobalMatches provided)", () => {
+    it("adds only unique matches in a single setGlobalMatches call and reports skip stats", () => {
+      const setGlobalMatches = jest.fn();
+      const { renderer, getLatest } = renderHarness(
+        [buildMatch()],
+        setGlobalMatches,
+      );
+
+      TestRenderer.act(() => {
+        getLatest().startProcessing([
+          buildMatchData({ id: "new-1", team1: "Arsenal FC", team2: "Chelsea FC" }),
+          buildMatchData({
+            id: "dup-1",
+            team1: "Liverpool FC",
+            team2: "Everton FC",
+          }),
+        ]);
+      });
+
+      expect(setGlobalMatches).toHaveBeenCalledTimes(1);
+      const [calledWith] = setGlobalMatches.mock.calls[0] as [Match[]];
+      expect(calledWith).toHaveLength(2);
+      expect(calledWith.some((m) => m.id === "new-1")).toBe(true);
+
+      // startProcessing already filters out matches that duplicate the
+      // existing list before processBatchDirectly ever sees them, so the
+      // duplicate never reaches (and never inflates) processBatchDirectly's
+      // own skip count -- only the unique candidate is counted here.
+      expect(getLatest().processingState.matchesAdded).toBe(1);
+      expect(getLatest().processingState.matchesSkipped).toBe(0);
+      expect(getLatest().processingState.totalToProcess).toBe(1);
+      expect(getLatest().isProcessing).toBe(false);
+
+      renderer.unmount();
+    });
+
+    it("does not call setGlobalMatches when every candidate already exists", () => {
+      const setGlobalMatches = jest.fn();
+      const consoleWarnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+
+      const { renderer, getLatest } = renderHarness(
+        [buildMatch()],
+        setGlobalMatches,
+      );
+
+      TestRenderer.act(() => {
+        getLatest().startProcessing([
+          buildMatchData({
+            id: "dup-1",
+            team1: "Liverpool FC",
+            team2: "Everton FC",
+          }),
+        ]);
+      });
+
+      expect(setGlobalMatches).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "All filtered matches are already in your list",
+      );
+
+      consoleWarnSpy.mockRestore();
+      renderer.unmount();
+    });
+  });
+
+  describe("guard clauses (shared by both paths)", () => {
+    it("warns and skips when no candidate has both teams filled in", () => {
+      const consoleWarnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+      const setGlobalMatches = jest.fn();
+
+      const { renderer, getLatest } = renderHarness([], setGlobalMatches);
+
+      TestRenderer.act(() => {
+        getLatest().startProcessing([
+          buildMatchData({ team1: "", team2: "Chelsea FC" }),
+        ]);
+      });
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith("No valid matches to add");
+      expect(setGlobalMatches).not.toHaveBeenCalled();
+
+      consoleWarnSpy.mockRestore();
+      renderer.unmount();
+    });
+
+    it("warns and ignores a new startProcessing call while one is already in progress", () => {
+      const consoleWarnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+
+      // No setGlobalMatches -> takes the sequential path, which sets isProcessing true.
+      const { renderer, getLatest } = renderHarness([]);
+
+      TestRenderer.act(() => {
+        getLatest().startProcessing([buildMatchData()]);
+      });
+
+      expect(getLatest().isProcessing).toBe(true);
+
+      TestRenderer.act(() => {
+        getLatest().startProcessing([
+          buildMatchData({ id: "second", team1: "X", team2: "Y" }),
+        ]);
+      });
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "Match processing is already in progress, ignoring new request",
+      );
+
+      consoleWarnSpy.mockRestore();
+      renderer.unmount();
+    });
+  });
+
+  describe("sequential path (no setGlobalMatches)", () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("processes one match end to end: sets teams, adds it, then clears processing state", async () => {
+      const { renderer, getLatest } = renderHarness([]);
+
+      TestRenderer.act(() => {
+        getLatest().startProcessing([
+          buildMatchData({ id: "m1", team1: "Arsenal FC", team2: "Chelsea FC" }),
+        ]);
+      });
+
+      expect(getLatest().isProcessing).toBe(true);
+
+      // Flush the effect that schedules the 100ms kick-off timer before advancing.
+      await TestRenderer.act(async () => {
+        await Promise.resolve();
+      });
+
+      // Drain the 100ms kick-off timer plus the internal 50ms polling loop.
+      for (let i = 0; i < 20; i += 1) {
+        await TestRenderer.act(async () => {
+          await jest.advanceTimersByTimeAsync(50);
+        });
+
+        if (getLatest().isProcessing === false) {
+          break;
+        }
+      }
+
+      expect(getLatest().homeTeamCalls).toContain("Arsenal FC");
+      expect(getLatest().awayTeamCalls).toContain("Chelsea FC");
+      expect(getLatest().matches).toHaveLength(1);
+      expect(getLatest().processingState.matchesAdded).toBe(1);
+      expect(getLatest().processingState.matchesSkipped).toBe(0);
+      expect(getLatest().isProcessing).toBe(false);
+
+      renderer.unmount();
+    });
+
+    it("skips a candidate that becomes a duplicate mid-batch (added by an earlier candidate in the same run)", async () => {
+      // startProcessing's own dedup pass only filters candidates against
+      // matches that exist *before* the run starts, so two identical
+      // candidates in the same call both get queued -- the in-flight
+      // "already exists" check inside processMatch is what catches the
+      // second one once the first has actually been added.
+      const { renderer, getLatest } = renderHarness([]);
+
+      TestRenderer.act(() => {
+        getLatest().startProcessing([
+          buildMatchData({ id: "m1", team1: "Arsenal FC", team2: "Chelsea FC" }),
+          buildMatchData({ id: "m2", team1: "Arsenal FC", team2: "Chelsea FC" }),
+        ]);
+      });
+
+      for (let i = 0; i < 40; i += 1) {
+        await TestRenderer.act(async () => {
+          await jest.advanceTimersByTimeAsync(50);
+        });
+
+        if (getLatest().isProcessing === false) {
+          break;
+        }
+      }
+
+      expect(getLatest().processingState.matchesSkipped).toBe(1);
+      expect(getLatest().processingState.matchesAdded).toBe(1);
+      expect(getLatest().matches).toHaveLength(1);
+
+      renderer.unmount();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds tests for the more complex remaining hooks, completing the Phase 7 gameProgress decomposition's deferred full test coverage (T038/T039):

- `useLegacyHistoryImport.test.ts` (9 tests) — phase machine (`checking→ready→importing→completed/failed`), auth gating, and `importHistory` short-circuit/caching behavior
- `useMatchProcessing.test.ts` (6 tests) — batch path (`setGlobalMatches`), guard clauses, and the sequential path driven with `jest.useFakeTimers()` + `advanceTimersByTimeAsync` for the 100ms kick-off and 50ms polling loop
- `hooks/gameProgress/*.test.ts` (20 tests) — direct tests for all 7 extracted pure reducers/helpers (`gameProgressUiReducer`, `toastQueueReducer`, `migrateLegacyMatch`, `calculateToastScoreDisplay`, `applyHomeGoalUpdate`, `applyAwayGoalUpdate`, `updateMatchForGoal`)
- `useGoalToastQueue.test.ts` (5 tests) — message formatting, one-at-a-time toast display gated on `onHide`, scoring-team props
- `useGameProgressController.test.ts` (9 tests) — slim Probe-based integration test of the composed controller, mocking `useLiveScores`, `expo-router`, and the platform hooks (`useAppVisibility`/`useGoalSound`) while exercising the real Zustand store; covers legacy-match migration on mount, polling start/stop, the full goal→sound→toast pipeline (including the common-match notification toggle), drink increment/decrement floor, refresh error handling, and end-game/navigation wiring

## Test plan
- [x] Each new file green in isolation and together
- [x] `npx jest --ci` — 78 suites / 392 tests (was 70/334 — +8 suites/+58 tests)
- [x] `npm run lint` — 0 errors, 298 warnings (matches pre-existing baseline exactly)
- [x] `npx tsc --noEmit` — 130 errors (matches pre-existing baseline exactly)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)